### PR TITLE
chore(release): 2.0.2 [skip ci]

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,13 @@
+ember-stereo changelog
+
+## [2.0.2](https://github.com/jkeen/ember-stereo/compare/v2.0.1...v2.0.2) (2021-09-04)
+
+
+### Bug Fixes
+
+* expose currentTime on the service and the base sound ([14103e9](https://github.com/jkeen/ember-stereo/commit/14103e914045c82fa242dd7f99884acee8c8d988))
+
+
+### Documentation
+
+* Update documentation and examples for using the test helpers ([f99e987](https://github.com/jkeen/ember-stereo/commit/f99e987f197ebd4e6f34591c47bff488d0f5a674))


### PR DESCRIPTION
## [2.0.2](https://github.com/jkeen/ember-stereo/compare/v2.0.1...v2.0.2) (2021-09-04)

### Bug Fixes

* expose currentTime on the service and the base sound ([14103e9](https://github.com/jkeen/ember-stereo/commit/14103e914045c82fa242dd7f99884acee8c8d988))

### Documentation

* Update documentation and examples for using the test helpers ([f99e987](https://github.com/jkeen/ember-stereo/commit/f99e987f197ebd4e6f34591c47bff488d0f5a674))