### PR TITLE
Fix ObjectCache usage with string keys

### DIFF
--- a/addon/-private/utils/object-cache.js
+++ b/addon/-private/utils/object-cache.js
@@ -1,45 +1,46 @@
 import { tracked } from '@glimmer/tracking';
 import normalizeIdentifier from './normalize-identifier';
-import { inject as service } from '@ember/service';
-import {
-  TrackedObject,
-  TrackedWeakMap,
-} from 'tracked-built-ins';
+import { TrackedObject, TrackedWeakMap } from 'tracked-built-ins';
+
+function isAnObject(identifier) {
+  return identifier.then || typeof identifier === 'object';
+}
 
 /**
-* This class caches things based on a strings or objects. You shouldn't have to interact with this class.
-*/
-
+ * This class caches things based on a strings or objects. You shouldn't have to interact with this class.
+ */
 export default class ObjectCache {
-  @service stereo;
-
   @tracked objectCache = new TrackedWeakMap();
-  @tracked keyCache = new TrackedObject()
-  name = 'ember-stereo:object-cache'
+  @tracked keyCache = new TrackedObject();
+  name = 'ember-stereo:object-cache';
 
   has(_identifier) {
     let identifier = normalizeIdentifier(_identifier);
-    return this.objectCache.has(identifier) || (identifier in this.keyCache)
+    if (isAnObject(identifier)) {
+      return this.objectCache.has(identifier);
+    } else {
+      return identifier in this.keyCache;
+    }
   }
 
   find(_identifier) {
     let identifier = normalizeIdentifier(_identifier);
 
-    if (this.objectCache.has(identifier)) {
-      return this.objectCache.get(identifier)
+    if (isAnObject(identifier) && this.objectCache.has(identifier)) {
+      return this.objectCache.get(identifier);
     } else if (this.keyCache[identifier]) {
-      return this.keyCache[identifier]
+      return this.keyCache[identifier];
     }
   }
 
   remove(_identifier) {
     let identifier = normalizeIdentifier(_identifier);
 
-    if (this.objectCache.has(identifier)) {
-      this.objectCache.remove(identifier)
+    if (isAnObject(identifier) && this.objectCache.has(identifier)) {
+      this.objectCache.delete(identifier);
     }
     if (this.keyCache[identifier]) {
-      delete this.keyCache[identifier]
+      delete this.keyCache[identifier];
     }
   }
 
@@ -47,10 +48,10 @@ export default class ObjectCache {
     let identifier = normalizeIdentifier(_identifier);
 
     if (identifier) {
-      if (identifier.then || (typeof identifier === 'object')) {
-        this.objectCache.set(identifier, value)
+      if (isAnObject(identifier)) {
+        this.objectCache.set(identifier, value);
       } else {
-        this.keyCache[identifier] = value
+        this.keyCache[identifier] = value;
       }
     }
   }

--- a/addon/-private/utils/object-cache.js
+++ b/addon/-private/utils/object-cache.js
@@ -1,4 +1,5 @@
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 import normalizeIdentifier from './normalize-identifier';
 import { TrackedObject, TrackedWeakMap } from 'tracked-built-ins';
 
@@ -10,6 +11,8 @@ function isAnObject(identifier) {
  * This class caches things based on a strings or objects. You shouldn't have to interact with this class.
  */
 export default class ObjectCache {
+  @service stereo; // used by subclasses
+
   @tracked objectCache = new TrackedWeakMap();
   @tracked keyCache = new TrackedObject();
   name = 'ember-stereo:object-cache';

--- a/addon/-private/utils/object-cache.js
+++ b/addon/-private/utils/object-cache.js
@@ -4,7 +4,11 @@ import normalizeIdentifier from './normalize-identifier';
 import { TrackedObject, TrackedWeakMap } from 'tracked-built-ins';
 
 function isAnObject(identifier) {
-  return identifier.then || typeof identifier === 'object';
+  return (
+    identifier !== undefined &&
+    identifier !== null &&
+    (typeof identifier === 'object' || identifier.then)
+  );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-modifier": "^3.0.0",
     "hls.js": "^1.1.1",
     "howler": "^2.2.1",
-    "tracked-built-ins": "^2.0.1",
+    "tracked-built-ins": "^3.1.0",
     "tracked-toolbox": "^1.2.1"
   },
   "devDependencies": {

--- a/tests/unit/utils/object-cache-test.js
+++ b/tests/unit/utils/object-cache-test.js
@@ -1,0 +1,94 @@
+import { module, test } from 'qunit';
+import ObjectCache from 'ember-stereo/-private/utils/object-cache';
+
+module('Unit | Utility | object-cache', function () {
+  test('stores values for object identifiers', function (assert) {
+    let objectCache = new ObjectCache();
+
+    let key1 = { whoAmI: 'the world may never know' };
+    let key2 = { foo: 'bar', baz: 123 };
+    let val1 = { value: 1 };
+    let val2 = 'hello';
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+
+    objectCache.store(key1, val1);
+    objectCache.store(key2, val2);
+
+    assert.ok(objectCache.has(key1));
+    assert.ok(objectCache.has(key2));
+    assert.deepEqual(objectCache.find(key1), val1);
+    assert.deepEqual(objectCache.find(key2), val2);
+
+    objectCache.remove(key1);
+    objectCache.remove(key2);
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+  });
+
+  test('stores values for string identifiers', function (assert) {
+    let objectCache = new ObjectCache();
+
+    let key1 = 'whoAmI';
+    let key2 = 'foo';
+    let val1 = { value: 1 };
+    let val2 = 'hello';
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+
+    objectCache.store(key1, val1);
+    objectCache.store(key2, val2);
+
+    assert.ok(objectCache.has(key1));
+    assert.ok(objectCache.has(key2));
+    assert.deepEqual(objectCache.find(key1), val1);
+    assert.deepEqual(objectCache.find(key2), val2);
+
+    objectCache.remove(key1);
+    objectCache.remove(key2);
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+  });
+
+  test('stores both at the same time', function (assert) {
+    let objectCache = new ObjectCache();
+
+    let key1 = 'whoAmI';
+    let key2 = { foo: 'bar', baz: 123 };
+    let val1 = { value: 1 };
+    let val2 = 'hello';
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+
+    objectCache.store(key1, val1);
+    objectCache.store(key2, val2);
+
+    assert.ok(objectCache.has(key1));
+    assert.ok(objectCache.has(key2));
+    assert.deepEqual(objectCache.find(key1), val1);
+    assert.deepEqual(objectCache.find(key2), val2);
+
+    objectCache.remove(key1);
+    objectCache.remove(key2);
+
+    assert.false(objectCache.has(key1));
+    assert.false(objectCache.has(key2));
+    assert.equal(objectCache.find(key1), null);
+    assert.equal(objectCache.find(key2), null);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7635,6 +7635,22 @@ ember-cli-typescript@^4.1.0, ember-cli-typescript@^4.2.1:
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
+ember-cli-typescript@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.1.0.tgz#460eb848564e29d64f2b36b2a75bbe98172b72a4"
+  integrity sha512-wEZfJPkjqFEZAxOYkiXsDrJ1HY75e/6FoGhQFg8oNFJeGYpIS/3W0tgyl1aRkSEEN1NRlWocDubJ4aZikT+RTA==
+  dependencies:
+    ansi-to-html "^0.6.15"
+    broccoli-stew "^3.0.0"
+    debug "^4.0.0"
+    execa "^4.0.0"
+    fs-extra "^9.0.1"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^7.3.2"
+    stagehand "^1.0.0"
+    walk-sync "^2.2.0"
+
 ember-cli-version-checker@^2.1.0, ember-cli-version-checker@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz#47771b731fe0962705e27c8199a9e3825709f3b3"
@@ -8191,7 +8207,7 @@ ember-tether@^2.0.1:
     ember-cli-babel "^7.1.2"
     tether "^1.4.0"
 
-ember-tracked-storage-polyfill@1.0.0, ember-tracked-storage-polyfill@^1.0.0:
+ember-tracked-storage-polyfill@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-tracked-storage-polyfill/-/ember-tracked-storage-polyfill-1.0.0.tgz#84d307a1e4badc5f84dca681db2cfea9bdee8a77"
   integrity sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==
@@ -16340,15 +16356,14 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-tracked-built-ins@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-2.0.1.tgz#9d6d0db29ad187e8533591f0e891e15b7a2259c5"
-  integrity sha512-v0DwPVNm3zA4cmJLpcBJxJfKefN6ldhkc8l5YA+cWHq7kI8WMUcXjIXgl/AIxmt1SoO1bwPdpikPRHHrIBDtFQ==
+tracked-built-ins@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tracked-built-ins/-/tracked-built-ins-3.1.0.tgz#827703e8e8857e45ac449dfc41e8706e0d6da309"
+  integrity sha512-yPEZV1aYaw7xFWdoEluvdwNxIJIA834HaBQaMATjNAYPwd1fRqIJ46YnuRo6+9mRRWu6nM6sJqrVVa5H6UhFuw==
   dependencies:
     ember-cli-babel "^7.26.10"
-    ember-cli-typescript "^4.1.0"
+    ember-cli-typescript "^5.1.0"
     ember-tracked-storage-polyfill "^1.0.0"
-    tracked-maps-and-sets "^3.0.2"
 
 tracked-maps-and-sets@^2.0.0:
   version "2.2.1"
@@ -16357,16 +16372,6 @@ tracked-maps-and-sets@^2.0.0:
   dependencies:
     "@glimmer/tracking" "^1.0.0"
     ember-cli-babel "^7.17.2"
-
-tracked-maps-and-sets@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz#6ea1b9f2a367d24f2e9905b74b24437fbce76ea6"
-  integrity sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==
-  dependencies:
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^4.2.1"
-    ember-tracked-storage-polyfill "1.0.0"
 
 tracked-toolbox@^1.2.1, tracked-toolbox@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
In my newly-created app, the latest version of `tracked-built-ins` was installed and used automatically which created some problems in how `ObjectCache` was using `TrackedWeakMap`. It seems that the newer version of that library more accurately represents the errors you'd get from using a regular `WeakMap`, so if you're passing string keys (i.e. URLs) to things that use `ObjectCache`, then you get errors around using something that isn't an object as a key:
```
VM611:1 Uncaught TypeError: Invalid value used as weak map key
```

I've attempted to fix that in this PR by always using the check you had in `store()` to check if the identifier is an object before using a weak map API. Additionally, `remove()` was broken because the weak map API there is named `delete()` not `remove()`. I found that second issue when adding tests to identify my original issue!