### PR TITLE
Allow authenticated requests by passing through xhr options to connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,6 @@ ember install ember-stereo
 >Play</button>
 ```
 
-- `pause-sound`
-
-```hbs
-<button
-  type='button'
-  class='button is-link'
-  {{on 'click' (pause-sound @identifier)}}
->Pause</button>
-```
-
 - `load-sound`
 
 ```hbs
@@ -69,6 +59,16 @@ ember install ember-stereo
   class='button is-link'
   {{on 'click' (load-sound @identifier)}}
 >Load</button>
+```
+
+- `pause-sound`
+
+```hbs
+<button
+  type='button'
+  class='button is-link'
+  {{on 'click' (pause-sound @identifier)}}
+>Pause</button>
 ```
 
 - `stop-sound`

--- a/addon/-private/utils/strategizer.js
+++ b/addon/-private/utils/strategizer.js
@@ -20,11 +20,16 @@ export default class Strategizer {
   }
 
   buildStrategy(connection, url) {
+    let passthroughOptions = {};
+    if (this.options.xhr) {
+      passthroughOptions.xhr = this.options?.xhr;
+    }
     let strategyOptions = {
       metadata: this.options.metadata,
       sharedAudioAccess: this.useSharedAudioAccess
         ? this.sharedAudioAccess
         : undefined,
+      options: passthroughOptions,
     };
 
     let strategy = new Strategy(

--- a/addon/helpers/load-sound.js
+++ b/addon/helpers/load-sound.js
@@ -20,6 +20,7 @@ export default class LoadSound extends Helper {
     @param {Any} identifier url, urls, url objects, promise that resolves to a url
     @param {Hash} metadata? metadata that should be included with the sound
     @param {[String]} useConnections? array of connection names in preference order
+    @param {[String]} xhr? hash of xhr options: { method: 'POST', headers: { Authorization: 'Bearer 1234'}, withCredentials: true }
     @return {Function}
   */
 

--- a/addon/helpers/play-sound.js
+++ b/addon/helpers/play-sound.js
@@ -19,6 +19,7 @@ import { didCancel } from 'ember-concurrency';
   @param {Any} identifier url, urls, url objects, promise that resolves to a url
   @param {Hash} metadata? metadata that should be included with the sound
   @param {[String]} useConnections? array of connection names in preference order
+  @param {[String]} xhr? hash of xhr options: { method: 'POST', headers: { Authorization: 'Bearer 1234'}, withCredentials: true }
   @return {Function}
 */
 export default class playSound extends StereoBaseActionHelper {

--- a/addon/helpers/toggle-play-sound.js
+++ b/addon/helpers/toggle-play-sound.js
@@ -18,6 +18,7 @@ import { didCancel } from 'ember-concurrency';
   @param {Any} identifier url, urls, url objects, promise that resolves to a url
   @param {Hash} metadata? metadata that should be included with the sound
   @param {[String]} useConnections? array of connection names in preference order
+  @param {[String]} xhr? hash of xhr options: { method: 'POST', headers: { Authorization: 'Bearer 1234'}, withCredentials: true }
   @return {Function}
 */
 export default class togglePlaySound extends StereoBaseActionHelper {

--- a/addon/stereo-connections/hls.js
+++ b/addon/stereo-connections/hls.js
@@ -31,7 +31,29 @@ export default class HLSSound extends BaseSound {
     let video = document.createElement('video');
     video.setAttribute('crossorigin', 'anonymous');
     this.video = video;
-    let hls = new HLS({ debug: false, startFragPrefetch: true });
+    let options = { debug: false, startFragPrefetch: true };
+
+    if (this.options.xhr) {
+      options.xhrSetup = (xhr, url) => {
+        if (this.url !== url && this.options.xhr?.manifestOnly) {
+          // If this isn't the manifest request and we've requested manifestOnly, don't set these options
+          return;
+        }
+
+        xhr.withCredentials = this.options.xhr?.withCredentials || false;
+
+        if (this.options?.xhr?.headers) {
+          Object.keys(this.options.xhr.headers).forEach((key) => {
+            xhr.setRequestHeader(key, this.options?.xhr?.headers[key]);
+          });
+        }
+
+        xhr.method = this.options.xhr?.method || 'GET';
+      };
+      delete this.options.xhr;
+    }
+
+    let hls = new HLS({ ...options, ...(this.options || {}) });
 
     this.hls = hls;
     this._setupHLSEvents(hls);

--- a/addon/stereo-connections/hls.js
+++ b/addon/stereo-connections/hls.js
@@ -33,7 +33,7 @@ export default class HLSSound extends BaseSound {
     this.video = video;
     let options = { debug: false, startFragPrefetch: true };
 
-    if (this.options.xhr) {
+    if (this.options?.xhr) {
       options.xhrSetup = (xhr, url) => {
         if (this.url !== url && this.options.xhr?.manifestOnly) {
           // If this isn't the manifest request and we've requested manifestOnly, don't set these options

--- a/addon/stereo-connections/howler.js
+++ b/addon/stereo-connections/howler.js
@@ -21,75 +21,80 @@ export default class Howler extends BaseSound {
   setup() {
     let urls = makeArray(this.url);
     let sound = this;
-    let options = Object.assign(
-      {
-        src: urls,
-        autoplay: false,
-        preload: true,
-        html5: true,
-        volume: 1,
-        onload: function () {
-          sound.url = this._src;
-          sound.howl = this;
-          sound.trigger('audio-loaded', { sound });
-          sound.trigger('audio-ready', { sound });
-        },
-        onpause: function () {
-          // if (!sound.isPlaying) {
-          sound.trigger('audio-paused', { sound });
-          // }
-        },
-        onplay: function () {
-          sound.trigger('audio-played', { sound });
-        },
-        onend: function () {
-          sound.trigger('audio-ended', { sound });
-        },
-        onstop: function () {
-          sound.trigger('audio-paused', { sound });
-        },
-        onloaderror: function (id, code) {
-          var MEDIA_NOT_ALLOWED = 0;
-          var MEDIA_ERR_ABORTED = 1;
-          var MEDIA_ERR_NETWORK = 2;
-          var MEDIA_ERR_DECODE = 3;
-          var MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
-
-          if (code === MEDIA_NOT_ALLOWED) {
-            sound.trigger('audio-blocked', {
-              sound,
-              error:
-                'Audio autoplay attempt was blocked by browser user settings',
-            });
-          } else {
-            let message = '';
-            switch (code) {
-              case MEDIA_ERR_ABORTED:
-                message = 'You aborted the audio playback.';
-                break;
-              case MEDIA_ERR_NETWORK:
-                message = 'A network error caused the audio download to fail.';
-                break;
-              case MEDIA_ERR_DECODE:
-                message = 'Decoder error.';
-                break;
-              case MEDIA_ERR_SRC_NOT_SUPPORTED:
-                message = 'Audio source format is not supported.';
-                break;
-              default:
-                message = 'Audio load error';
-                break;
-            }
-
-            sound.trigger('audio-load-error', { sound, error: message });
-          }
-        },
-        onseek: function () {
-          sound.trigger('audio-position-changed', { sound });
-        },
+    let options = Object.assign({
+      src: urls,
+      autoplay: false,
+      preload: true,
+      html5: true,
+      volume: 1,
+      onload: function () {
+        sound.url = this._src;
+        sound.howl = this;
+        sound.trigger('audio-loaded', { sound });
+        sound.trigger('audio-ready', { sound });
       },
-      this.options
-    );
+      onpause: function () {
+        // if (!sound.isPlaying) {
+        sound.trigger('audio-paused', { sound });
+        // }
+      },
+      onplay: function () {
+        sound.trigger('audio-played', { sound });
+      },
+      onend: function () {
+        sound.trigger('audio-ended', { sound });
+      },
+      onstop: function () {
+        sound.trigger('audio-paused', { sound });
+      },
+      onloaderror: function (id, code) {
+        var MEDIA_NOT_ALLOWED = 0;
+        var MEDIA_ERR_ABORTED = 1;
+        var MEDIA_ERR_NETWORK = 2;
+        var MEDIA_ERR_DECODE = 3;
+        var MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+
+        if (code === MEDIA_NOT_ALLOWED) {
+          sound.trigger('audio-blocked', {
+            sound,
+            error:
+              'Audio autoplay attempt was blocked by browser user settings',
+          });
+        } else {
+          let message = '';
+          switch (code) {
+            case MEDIA_ERR_ABORTED:
+              message = 'You aborted the audio playback.';
+              break;
+            case MEDIA_ERR_NETWORK:
+              message = 'A network error caused the audio download to fail.';
+              break;
+            case MEDIA_ERR_DECODE:
+              message = 'Decoder error.';
+              break;
+            case MEDIA_ERR_SRC_NOT_SUPPORTED:
+              message = 'Audio source format is not supported.';
+              break;
+            default:
+              message = 'Audio load error';
+              break;
+          }
+
+          sound.trigger('audio-load-error', { sound, error: message });
+        }
+      },
+      onseek: function () {
+        sound.trigger('audio-position-changed', { sound });
+      },
+    });
+
+    if (this.options.xhr) {
+      options.xhr = {
+        withCredentials: this.options.xhr?.withCredentials || false,
+        headers: this.options.xhr?.headers || {},
+        method: this.options.xhr?.method || 'GET',
+      };
+    }
 
     this.howl = new Howl(options);
   }

--- a/addon/stereo-connections/native-audio.js
+++ b/addon/stereo-connections/native-audio.js
@@ -62,7 +62,14 @@ export default class NativeAudio extends BaseSound {
       audio.muted = true;
     }
 
-    audio.load();
+    if (this.options?.xhr) {
+      return this.trigger('audio-load-error', {
+        sound: this,
+        error: 'xhr is not supported in NativeAudio',
+      });
+    } else {
+      audio.load();
+    }
   }
 
   _registerEvents(audio) {
@@ -426,7 +433,7 @@ export default class NativeAudio extends BaseSound {
   }
 
   get shouldRetry() {
-    return this.retryCount < 1;
+    return this.retryCount < 1 && !this.options?.xhr;
   }
 
   retry() {

--- a/addon/stereo-connections/native-audio.js
+++ b/addon/stereo-connections/native-audio.js
@@ -65,7 +65,7 @@ export default class NativeAudio extends BaseSound {
     if (this.options?.xhr) {
       return this.trigger('audio-load-error', {
         sound: this,
-        error: 'xhr is not supported in NativeAudio',
+        error: 'xhr options are not supported in NativeAudio',
       });
     } else {
       audio.load();

--- a/tests/unit/stereo-connections/native-audio-test.js
+++ b/tests/unit/stereo-connections/native-audio-test.js
@@ -414,4 +414,25 @@ module('Unit | Connection | Native Audio', function (hooks) {
       'second try should be null'
     );
   });
+
+  test('does not support xhr options', async function (assert) {
+    assert.expect(4);
+    let stereo = this.owner.lookup('service:stereo');
+    let url1 = '/good/5000/silence.mp3';
+
+    let { failures } = await stereo.load(url1, {
+      silenceErrors: true,
+      useConnections: ['NativeAudio'],
+      xhr: {
+        withCredentials: true,
+      },
+    });
+
+    let erroredSound = failures[0].erroredSound;
+    assert.strictEqual(erroredSound.retryCount, 0);
+    assert.strictEqual(
+      erroredSound.error,
+      'xhr is not supported in NativeAudio'
+    );
+  });
 });

--- a/tests/unit/stereo-connections/native-audio-test.js
+++ b/tests/unit/stereo-connections/native-audio-test.js
@@ -416,7 +416,7 @@ module('Unit | Connection | Native Audio', function (hooks) {
   });
 
   test('does not support xhr options', async function (assert) {
-    assert.expect(4);
+    assert.expect(2);
     let stereo = this.owner.lookup('service:stereo');
     let url1 = '/good/5000/silence.mp3';
 
@@ -428,11 +428,11 @@ module('Unit | Connection | Native Audio', function (hooks) {
       },
     });
 
-    let erroredSound = failures[0].erroredSound;
+    let erroredSound = failures[0]?.erroredSound;
     assert.strictEqual(erroredSound.retryCount, 0);
     assert.strictEqual(
       erroredSound.error,
-      'xhr is not supported in NativeAudio'
+      'xhr options are not supported in NativeAudio'
     );
   });
 });


### PR DESCRIPTION
This adds an xhr option so that when loading/playing sounds, you can provide the xhr params necessary to perform an authenticated request.

The available parameters are:
`xhr.withCredentials`, `xhr.headers`, and `xhr.method`. These attributes will configure the `Howler` connection's `xhr` property, and the `HLS` connection's `xhrSetup` function.


Using this in a template helper might look something: 

```hbs
<button
      type='button'
      {{on
        'click'
        (toggle-play-sound
          this.url
          xhr=(hash
            headers=(hash
              X-ACCESS-TOKEN='xyz123'
            )
          )
        )
      }}
    >
    {{#if (sound-is-playing this.url)}}
      Pause
    {{else}}
      Play
    {{/if}}
</button>
```

This isn't yet implemented in the NativeAudio connection yet, which requires more significant changes to support something like this. 