### PR TITLE
Relax the peerDependency on `@ember/test-waiters`

### DIFF
--- a/ember-stereo/package.json
+++ b/ember-stereo/package.json
@@ -91,7 +91,7 @@
   "peerDependencies": {
     "@babel/core": "^7.17.10",
     "@ember/string": ">=4",
-    "@ember/test-waiters": "^3.0.2"
+    "@ember/test-waiters": "^3.0.2 || >= 4.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ember/render-modifiers':
         specifier: ^1.0.2
-        version: 1.0.2(@babel/core@7.28.0)
+        version: 1.0.2(@babel/core@7.24.3)
       '@glimmer/tracking':
         specifier: ^1.0.4
         version: 1.1.2
@@ -31,16 +31,16 @@ importers:
         version: 5.7.2
       ember-concurrency:
         specifier: ^2.1.2
-        version: 2.3.7(@babel/core@7.28.0)
+        version: 2.3.7(@babel/core@7.24.3)
       ember-get-config:
         specifier: ^0.3.0
         version: 0.3.0
       ember-modifier:
         specifier: ^2.1.1
-        version: 2.1.2(@babel/core@7.28.0)
+        version: 2.1.2(@babel/core@7.24.3)
       ember-poll:
         specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.28.0)
+        version: 1.4.0(@babel/core@7.24.3)
       hls.js:
         specifier: ^1.0.9
         version: 1.5.15
@@ -49,14 +49,14 @@ importers:
         version: 2.2.4
       tracked-toolbox:
         specifier: ^1.2.1
-        version: 1.3.0(@babel/core@7.28.0)
+        version: 1.3.0(@babel/core@7.24.3)
     devDependencies:
       '@ember/optional-features':
         specifier: ^2.0.0
         version: 2.0.0
       '@ember/test-helpers':
         specifier: ^2.2.5
-        version: 2.9.3(@babel/core@7.28.0)(ember-source@3.27.5)
+        version: 2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       '@ember/test-waiters':
         specifier: ^2.4.2
         version: 2.4.5
@@ -68,10 +68,10 @@ importers:
         version: 4.1.3(postcss@8.4.38)
       '@glimmer/component':
         specifier: ^1.0.4
-        version: 1.1.2(@babel/core@7.28.0)
+        version: 1.1.2(@babel/core@7.24.3)
       '@tailwindcss/forms':
         specifier: ^0.3.3
-        version: 0.3.4(tailwindcss@2.2.19)
+        version: 0.3.4(tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.38))(postcss@8.4.38))
       autoprefixer:
         specifier: ^10.3.1
         version: 10.4.14(postcss@8.4.38)
@@ -86,10 +86,10 @@ importers:
         version: 3.0.1
       ember-cli:
         specifier: ~3.27.0
-        version: 3.27.0(debug@4.3.2)
+        version: 3.27.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       ember-cli-addon-docs:
         specifier: github:ember-learn/ember-cli-addon-docs
-        version: https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d(@babel/core@7.28.0)(@ember/string@4.0.1)(@ember/test-helpers@2.9.3)(ember-data@3.28.13)(ember-source@3.27.5)(webpack@5.91.0)
+        version: https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d(giiqxtp36gcmbqr7jn4efnbz7u)
       ember-cli-addon-docs-yuidoc:
         specifier: ^1.0.0
         version: 1.0.0
@@ -101,10 +101,10 @@ importers:
         version: 1.0.3
       ember-cli-custom-assertions:
         specifier: ^0.2.0
-        version: 0.2.0(@babel/core@7.28.0)
+        version: 0.2.0(@babel/core@7.24.3)
       ember-cli-dependency-checker:
         specifier: ^3.2.0
-        version: 3.3.1(ember-cli@3.27.0)
+        version: 3.3.1(ember-cli@3.27.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6))
       ember-cli-deploy:
         specifier: ^1.0.2
         version: 1.0.2
@@ -113,7 +113,7 @@ importers:
         version: 2.0.0
       ember-cli-deploy-git:
         specifier: ^1.3.4
-        version: 1.3.4(@babel/core@7.28.0)
+        version: 1.3.4(@babel/core@7.24.3)
       ember-cli-deploy-git-ci:
         specifier: ^1.0.1
         version: 1.0.1
@@ -137,7 +137,7 @@ importers:
         version: 4.5.0
       ember-data:
         specifier: ^3.24.0
-        version: 3.28.13(@babel/core@7.28.0)
+        version: 3.28.13(@babel/core@7.24.3)
       ember-decorators:
         specifier: ^6.1.1
         version: 6.1.1
@@ -158,28 +158,28 @@ importers:
         version: 0.0.4
       ember-load-initializers:
         specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.28.0)
+        version: 2.1.2(@babel/core@7.24.3)
       ember-maybe-import-regenerator:
         specifier: ^0.1.6
-        version: 0.1.6(@babel/core@7.28.0)
+        version: 0.1.6(@babel/core@7.24.3)
       ember-page-title:
         specifier: ^6.2.2
         version: 6.2.2
       ember-qunit:
         specifier: ^5.1.4
-        version: 5.1.5(@ember/test-helpers@2.9.3)(qunit@2.19.4)
+        version: 5.1.5(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)))(qunit@2.19.4)
       ember-resolver:
         specifier: ^8.0.2
-        version: 8.1.0(@babel/core@7.28.0)
+        version: 8.1.0(@babel/core@7.24.3)
       ember-sinon:
         specifier: ^5.0.0
         version: 5.0.0
       ember-sortable:
         specifier: ^2.2.5
-        version: 2.4.0(@babel/core@7.28.0)
+        version: 2.4.0(@babel/core@7.24.3)
       ember-source:
         specifier: ~3.27.2
-        version: 3.27.5(@babel/core@7.28.0)
+        version: 3.27.5(@babel/core@7.24.3)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
@@ -218,7 +218,7 @@ importers:
         version: 11.1.0(eslint@7.32.0)
       eslint-plugin-prettier:
         specifier: ^3.4.0
-        version: 3.4.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8)
+        version: 3.4.1(eslint-config-prettier@8.8.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8)
       eslint-plugin-qunit:
         specifier: ^6.1.1
         version: 6.2.0(eslint@7.32.0)
@@ -260,7 +260,7 @@ importers:
         version: 1.6.0
       tailwindcss:
         specifier: ^2.2.7
-        version: 2.2.19(autoprefixer@10.4.14)(postcss@8.4.38)
+        version: 2.2.19(autoprefixer@10.4.14(postcss@8.4.38))(postcss@8.4.38)
       tailwindcss-theming:
         specifier: ^3.0.0-beta.3
         version: 3.0.0-beta.3
@@ -285,19 +285,19 @@ importers:
         version: 2.0.0
       '@ember/test-helpers':
         specifier: ^2.9.3
-        version: 2.9.3(@babel/core@7.28.0)(ember-source@4.8.4)
+        version: 2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       '@fullhuman/postcss-purgecss':
         specifier: ^4.1.3
         version: 4.1.3(postcss@8.4.23)
       '@glimmer/component':
         specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.28.0)
+        version: 1.1.2(@babel/core@7.24.3)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
       '@tailwindcss/forms':
         specifier: ^0.3.4
-        version: 0.3.4(tailwindcss@2.2.19)
+        version: 0.3.4(tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.23))(postcss@8.4.23))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.4.14(postcss@8.4.23)
@@ -312,10 +312,10 @@ importers:
         version: 2.6.3(webpack@5.81.0)
       ember-cli:
         specifier: ~4.8.0
-        version: 4.8.0(debug@4.3.2)
+        version: 4.8.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       ember-cli-addon-docs:
         specifier: ^7.0.0
-        version: 7.0.0(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(ember-data@4.7.3)(ember-fetch@8.1.2)(ember-source@4.8.4)(webpack@5.81.0)
+        version: 7.0.0(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-data@4.7.3(@babel/core@7.24.3)(webpack@5.81.0))(ember-fetch@8.1.2)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
       ember-cli-addon-docs-yuidoc:
         specifier: ^1.0.0
         version: 1.0.0
@@ -327,7 +327,7 @@ importers:
         version: 7.26.11
       ember-cli-dependency-checker:
         specifier: ^3.3.1
-        version: 3.3.1(ember-cli@4.8.0)
+        version: 3.3.1(ember-cli@4.8.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6))
       ember-cli-deploy:
         specifier: ^1.0.2
         version: 1.0.2
@@ -336,7 +336,7 @@ importers:
         version: 2.0.0
       ember-cli-deploy-git:
         specifier: ^1.3.4
-        version: 1.3.4(@babel/core@7.28.0)
+        version: 1.3.4(@babel/core@7.24.3)
       ember-cli-deploy-git-ci:
         specifier: ^1.0.1
         version: 1.0.1
@@ -360,7 +360,7 @@ importers:
         version: 5.0.0
       ember-data:
         specifier: ~4.7.3
-        version: 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+        version: 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       ember-event-helpers:
         specifier: ^0.1.1
         version: 0.1.1
@@ -372,28 +372,28 @@ importers:
         version: 0.0.4
       ember-keyboard:
         specifier: 8.2.1
-        version: 8.2.1(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(ember-source@4.8.4)
+        version: 8.2.1(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-load-initializers:
         specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.28.0)
+        version: 2.1.2(@babel/core@7.24.3)
       ember-page-title:
         specifier: ^7.0.0
         version: 7.0.0
       ember-qunit:
         specifier: ^6.0.0
-        version: 6.2.0(@ember/test-helpers@2.9.3)(ember-source@4.8.4)(qunit@2.19.4)(webpack@5.81.0)
+        version: 6.2.0(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(qunit@2.19.4)(webpack@5.81.0)
       ember-resolver:
         specifier: ^8.1.0
-        version: 8.1.0(@babel/core@7.28.0)
+        version: 8.1.0(@babel/core@7.24.3)
       ember-source:
         specifier: ~4.8.0
-        version: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+        version: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
       ember-stereo:
         specifier: workspace:../ember-stereo
-        version: file:ember-stereo(@babel/core@7.28.0)(@ember/string@4.0.1)(@ember/test-waiters@3.1.0)(ember-source@4.8.4)(webpack@5.81.0)
+        version: file:ember-stereo(@babel/core@7.24.3)(@ember/string@4.0.1)(@ember/test-waiters@3.1.0)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
       ember-style-modifier:
         specifier: 4.3.0
-        version: 4.3.0(@ember/string@4.0.1)(ember-source@4.8.4)
+        version: 4.3.0(@ember/string@4.0.1)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-svg-jar:
         specifier: ^2.4.2
         version: 2.4.2
@@ -402,7 +402,7 @@ importers:
         version: 4.18.2
       ember-truth-helpers:
         specifier: '*'
-        version: 4.0.3(ember-source@4.8.4)
+        version: 4.0.3(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-useragent:
         specifier: ^0.12.0
         version: 0.12.0
@@ -420,7 +420,7 @@ importers:
         version: 11.1.0(eslint@7.32.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@7.32.0)
@@ -447,7 +447,7 @@ importers:
         version: 2.0.0
       tailwindcss:
         specifier: ^2.2.19
-        version: 2.2.19(autoprefixer@10.4.14)(postcss@8.4.23)
+        version: 2.2.19(autoprefixer@10.4.14(postcss@8.4.23))(postcss@8.4.23)
       tailwindcss-theming:
         specifier: 3.0.0-beta.3
         version: 3.0.0-beta.3
@@ -467,8 +467,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       '@ember/test-waiters':
-        specifier: ^3.0.2
-        version: 3.0.2
+        specifier: ^3.0.2 || >= 4.0.0
+        version: 3.1.0
       '@embroider/addon-shim':
         specifier: 1.6.0
         version: 1.6.0
@@ -504,7 +504,7 @@ importers:
         version: 2.1.1
       ember-modifier:
         specifier: ^4.0.0
-        version: 4.1.0(ember-source@5.0.0)
+        version: 4.1.0(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0))
       ember-sinon:
         specifier: ^5.0.0
         version: 5.0.0
@@ -519,7 +519,7 @@ importers:
         version: 3.1.1
       tracked-toolbox:
         specifier: ^2.0.0
-        version: 2.0.0(@babel/core@7.17.10)(ember-source@5.0.0)
+        version: 2.0.0(@babel/core@7.17.10)(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0))
     devDependencies:
       '@babel/plugin-proposal-class-properties':
         specifier: 7.16.7
@@ -556,7 +556,7 @@ importers:
         version: 7.1.0
       ember-resources:
         specifier: ^4.7.1
-        version: 4.10.0(@ember/test-waiters@3.0.2)(@glimmer/tracking@1.1.2)(ember-concurrency@2.3.7)(ember-source@5.0.0)
+        version: 4.10.0(@ember/test-waiters@3.1.0)(@glimmer/tracking@1.1.2)(ember-concurrency@2.3.7(@babel/core@7.17.10))(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0))
       ember-template-lint:
         specifier: ^3.16.0
         version: 3.16.0
@@ -577,7 +577,7 @@ importers:
         version: 0.5.1(eslint@7.32.0)
       eslint-plugin-import:
         specifier: 2.26.0
-        version: 2.26.0(@typescript-eslint/parser@5.21.0)(eslint@7.32.0)
+        version: 2.26.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint@7.32.0)
       eslint-plugin-json:
         specifier: 3.1.0
         version: 3.1.0
@@ -586,7 +586,7 @@ importers:
         version: 11.1.0(eslint@7.32.0)
       eslint-plugin-prettier:
         specifier: 4.0.0
-        version: 4.0.0(eslint-config-prettier@8.5.0)(eslint@7.32.0)(prettier@2.8.8)
+        version: 4.0.0(eslint-config-prettier@8.5.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.6.2)
       eslint-plugin-simple-import-sort:
         specifier: 7.0.0
         version: 7.0.0(eslint@7.32.0)
@@ -601,10 +601,10 @@ importers:
     devDependencies:
       '@babel/eslint-parser':
         specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.28.0)(eslint@8.42.0)
+        version: 7.22.5(@babel/core@7.24.3)(eslint@8.42.0)
       '@babel/plugin-proposal-decorators':
         specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.28.0)
+        version: 7.22.5(@babel/core@7.24.3)
       '@ember/optional-features':
         specifier: ^2.0.0
         version: 2.0.0
@@ -613,13 +613,13 @@ importers:
         version: 3.1.1
       '@ember/test-helpers':
         specifier: ^3.0.3
-        version: 3.0.3(ember-source@5.0.0)(webpack@5.89.0)
+        version: 3.0.3(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0)
       '@embroider/test-setup':
         specifier: ^1.8.3
         version: 1.8.3
       '@glimmer/component':
         specifier: ^1.1.2
-        version: 1.1.2(@babel/core@7.28.0)
+        version: 1.1.2(@babel/core@7.24.3)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
@@ -640,10 +640,10 @@ importers:
         version: 2.6.3(webpack@5.89.0)
       ember-cli:
         specifier: ~5.0.0
-        version: 5.0.0(debug@4.3.2)
+        version: 5.0.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       ember-cli-app-version:
         specifier: ^6.0.0
-        version: 6.0.0(ember-source@5.0.0)
+        version: 6.0.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-cli-babel:
         specifier: ^7.26.11
         version: 7.26.11
@@ -655,7 +655,7 @@ importers:
         version: 0.3.0
       ember-cli-dependency-checker:
         specifier: ^3.3.1
-        version: 3.3.1(ember-cli@5.0.0)
+        version: 3.3.1(ember-cli@5.0.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6))
       ember-cli-htmlbars:
         specifier: ^6.2.0
         version: 6.2.0
@@ -670,40 +670,40 @@ importers:
         version: 4.0.2
       ember-data:
         specifier: ~5.0.0
-        version: 5.0.0(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+        version: 5.0.0(@babel/core@7.24.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-fetch:
         specifier: ^8.1.2
         version: 8.1.2
       ember-load-initializers:
         specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.28.0)
+        version: 2.1.2(@babel/core@7.24.3)
       ember-modifier:
         specifier: ^4.1.0
-        version: 4.1.0(ember-source@5.0.0)
+        version: 4.1.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-page-title:
         specifier: ^7.0.0
         version: 7.0.0
       ember-qunit:
         specifier: ^7.0.0
-        version: 7.0.0(@ember/test-helpers@3.0.3)(ember-source@5.0.0)(qunit@2.19.4)(webpack@5.89.0)
+        version: 7.0.0(@ember/test-helpers@3.0.3(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0))(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(qunit@2.19.4)(webpack@5.89.0)
       ember-resolver:
         specifier: ^10.1.0
-        version: 10.1.0(@ember/string@3.1.1)(ember-source@5.0.0)
+        version: 10.1.0(@ember/string@3.1.1)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-sinon:
         specifier: ^5.0.0
         version: 5.0.0
       ember-sinon-qunit:
         specifier: 7.1.4
-        version: 7.1.4(ember-source@5.0.0)(qunit@2.19.4)(sinon@15.2.0)(webpack@5.89.0)
+        version: 7.1.4(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(qunit@2.19.4)(sinon@15.2.0)(webpack@5.89.0)
       ember-source:
         specifier: ~5.0.0
-        version: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+        version: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0
       ember-stereo:
         specifier: workspace:../ember-stereo
-        version: file:ember-stereo(@babel/core@7.28.0)(@ember/string@3.1.1)(@ember/test-waiters@3.1.0)(ember-source@5.0.0)(webpack@5.89.0)
+        version: file:ember-stereo(@babel/core@7.24.3)(@ember/string@3.1.1)(@ember/test-waiters@3.1.0)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0)
       ember-template-lint:
         specifier: ^5.10.1
         version: 5.10.1
@@ -724,7 +724,7 @@ importers:
         version: 16.0.0(eslint@8.42.0)
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8)
+        version: 4.2.1(eslint-config-prettier@8.8.0(eslint@8.42.0))(eslint@8.42.0)(prettier@2.8.8)
       eslint-plugin-qunit:
         specifier: ^7.3.4
         version: 7.3.4(eslint@8.42.0)
@@ -742,13 +742,13 @@ importers:
         version: 2.0.0
       stylelint:
         specifier: ^15.7.0
-        version: 15.7.0
+        version: 15.7.0(typescript@5.9.2)
       stylelint-config-standard:
         specifier: ^33.0.0
-        version: 33.0.0(stylelint@15.7.0)
+        version: 33.0.0(stylelint@15.7.0(typescript@5.9.2))
       stylelint-prettier:
         specifier: ^3.0.0
-        version: 3.0.0(prettier@2.8.8)(stylelint@15.7.0)
+        version: 3.0.0(prettier@2.8.8)(stylelint@15.7.0(typescript@5.9.2))
       tracked-built-ins:
         specifier: ^3.1.1
         version: 3.1.1
@@ -3630,7 +3630,6 @@ packages:
 
   '@tunein/howler@https://codeload.github.com/tunein/howler.js/tar.gz/5cd1ecff8d6df8f8793bd7126ccab317ea37feb4':
     resolution: {tarball: https://codeload.github.com/tunein/howler.js/tar.gz/5cd1ecff8d6df8f8793bd7126ccab317ea37feb4}
-    name: '@tunein/howler'
     version: 2.4.1
 
   '@types/acorn@4.0.6':
@@ -6574,7 +6573,6 @@ packages:
 
   ember-cli-addon-docs@https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d:
     resolution: {tarball: https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d}
-    name: ember-cli-addon-docs
     version: 8.0.8
     engines: {node: '>= 20.19'}
     peerDependencies:
@@ -7134,12 +7132,11 @@ packages:
 
   ember-stereo@file:ember-stereo:
     resolution: {directory: ember-stereo, type: directory}
-    name: ember-stereo
     engines: {node: 14.* || >= 16}
     peerDependencies:
       '@babel/core': ^7.17.10
       '@ember/string': '>=4'
-      '@ember/test-waiters': ^3.0.2
+      '@ember/test-waiters': ^3.0.2 || >= 4.0.0
 
   ember-style-modifier@4.3.0:
     resolution: {integrity: sha512-fL82w/sYu5LibLcM2t7K3CjE+SacgHYX7+ovSHBT5L2HJf1Mjnx5/UNe4/1zdwWqyw2mtik3qJdUpJjP+MSeNg==}
@@ -13684,9 +13681,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.22.5(@babel/core@7.28.0)(eslint@8.42.0)':
+  '@babel/eslint-parser@7.22.5(@babel/core@7.24.3)(eslint@8.42.0)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.42.0
       eslint-visitor-keys: 2.1.0
@@ -13792,6 +13789,30 @@ snapshots:
       '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-replace-supers': 7.24.1(@babel/core@7.17.10)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-split-export-declaration': 7.22.6
+
+  '@babel/helper-create-class-features-plugin@7.21.4(@babel/core@7.24.3)':
+    dependencies:
+      '@babel/core': 7.24.3
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.3)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-split-export-declaration': 7.22.6
+
+  '@babel/helper-create-class-features-plugin@7.21.4(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.28.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/helper-split-export-declaration': 7.22.6
 
@@ -14526,18 +14547,14 @@ snapshots:
   '@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.24.3)':
     dependencies:
       '@babel/core': 7.24.3
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.24.3)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.24.3)
+      '@babel/helper-plugin-utils': 7.20.2
 
   '@babel/plugin-proposal-class-properties@7.16.7(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.20.2
 
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.4)':
     dependencies:
@@ -14579,27 +14596,14 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/plugin-syntax-decorators': 7.24.0(@babel/core@7.21.4)
 
-  '@babel/plugin-proposal-decorators@7.22.5(@babel/core@7.21.4)':
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.21.4)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.21.4)
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.21.4)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-decorators@7.22.5(@babel/core@7.24.3)':
     dependencies:
       '@babel/core': 7.24.3
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.24.3)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-replace-supers': 7.27.1(@babel/core@7.24.3)
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.24.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/plugin-syntax-decorators': 7.24.0(@babel/core@7.24.3)
 
   '@babel/plugin-proposal-decorators@7.22.5(@babel/core@7.28.0)':
     dependencies:
@@ -14649,11 +14653,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.4)
 
-  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.28.0)':
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.3)
 
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.4)':
     dependencies:
@@ -14683,12 +14687,12 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.4)
 
-  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.28.0)':
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.3)
 
   '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.4)':
     dependencies:
@@ -14816,15 +14820,15 @@ snapshots:
       '@babel/core': 7.23.7
       '@babel/helper-plugin-utils': 7.24.0
 
+  '@babel/plugin-syntax-decorators@7.24.0(@babel/core@7.24.3)':
+    dependencies:
+      '@babel/core': 7.24.3
+      '@babel/helper-plugin-utils': 7.24.0
+
   '@babel/plugin-syntax-decorators@7.24.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.21.4)':
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.21.5)':
     dependencies:
@@ -15056,9 +15060,9 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.28.0)':
+  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.17.10)':
@@ -15201,11 +15205,6 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.24.3)':
     dependencies:
       '@babel/core': 7.24.3
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.28.0)':
-    dependencies:
-      '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.24.1(@babel/core@7.24.3)':
@@ -15840,9 +15839,9 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-object-assign@7.25.7(@babel/core@7.28.0)':
+  '@babel/plugin-transform-object-assign@7.25.7(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.24.3)':
@@ -16249,11 +16248,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.4.5(@babel/core@7.28.0)':
+  '@babel/plugin-transform-typescript@7.4.5(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.3)
 
   '@babel/plugin-transform-typescript@7.5.5(@babel/core@7.17.10)':
     dependencies:
@@ -16264,21 +16263,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.5.5(@babel/core@7.28.0)':
+  '@babel/plugin-transform-typescript@7.5.5(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
+      '@babel/core': 7.24.3
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.24.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.8.7(@babel/core@7.28.0)':
+  '@babel/plugin-transform-typescript@7.8.7(@babel/core@7.24.3)':
     dependencies:
-      '@babel/core': 7.28.0
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.28.0)
+      '@babel/core': 7.24.3
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.3)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.3)
 
   '@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.21.4)':
     dependencies:
@@ -16872,7 +16871,7 @@ snapshots:
 
   '@csstools/css-tokenizer@2.2.4': {}
 
-  '@csstools/media-query-list-parser@2.1.9(@csstools/css-parser-algorithms@2.6.1)(@csstools/css-tokenizer@2.2.4)':
+  '@csstools/media-query-list-parser@2.1.9(@csstools/css-parser-algorithms@2.6.1(@csstools/css-tokenizer@2.2.4))(@csstools/css-tokenizer@2.2.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 2.6.1(@csstools/css-tokenizer@2.2.4)
       '@csstools/css-tokenizer': 2.2.4
@@ -16899,10 +16898,10 @@ snapshots:
 
   '@ctrl/tinycolor@3.6.0': {}
 
-  '@ember-data/adapter@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/adapter@3.28.13(@babel/core@7.24.3)':
     dependencies:
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/store': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/store': 3.28.13(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
@@ -16912,10 +16911,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/adapter@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/adapter@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
-      '@ember-data/store': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
+      '@ember-data/store': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       ember-auto-import: 2.7.2(webpack@5.81.0)
@@ -16928,10 +16927,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/adapter@5.0.0(@ember-data/store@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)':
+  '@ember-data/adapter@5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)))(@ember/string@3.1.1)(ember-inflector@4.0.2)':
     dependencies:
       '@ember-data/private-build-infra': 5.0.0
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
@@ -16940,6 +16939,20 @@ snapshots:
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
+
+  '@ember-data/adapter@5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3)))(@ember/string@4.0.1)(ember-inflector@4.0.2)':
+    dependencies:
+      '@ember-data/private-build-infra': 5.0.0
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3))
+      '@ember/string': 4.0.1
+      '@embroider/macros': 1.15.0
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-inflector: 4.0.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    optional: true
 
   '@ember-data/canary-features@3.28.13':
     dependencies:
@@ -16955,9 +16968,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-data/debug@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/debug@3.28.13(@babel/core@7.24.3)':
     dependencies:
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
@@ -16967,9 +16980,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/debug@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/debug@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       ember-auto-import: 2.7.2(webpack@5.81.0)
@@ -17002,7 +17015,7 @@ snapshots:
   '@ember-data/graph@5.0.0(@ember-data/store@5.0.0)':
     dependencies:
       '@ember-data/private-build-infra': 5.0.0
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
@@ -17014,7 +17027,7 @@ snapshots:
     dependencies:
       '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
       '@ember-data/private-build-infra': 5.0.0
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember/edition-utils': 1.2.0
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
@@ -17024,48 +17037,49 @@ snapshots:
 
   '@ember-data/legacy-compat@5.0.0(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)':
     dependencies:
-      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
-      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
       '@ember-data/private-build-infra': 5.0.0
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
+    optionalDependencies:
+      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
+      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/model@3.28.13(@babel/core@7.24.3)':
     dependencies:
       '@ember-data/canary-features': 3.28.13
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/store': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/store': 3.28.13(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
-      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.28.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 4.2.1
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
       inflection: 1.13.4
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/model@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/model@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
       '@ember-data/canary-features': 4.7.3
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
-      '@ember-data/store': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
+      '@ember-data/store': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.10.0
       ember-auto-import: 2.7.2(webpack@5.81.0)
-      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.28.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 5.2.1
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
       inflection: 1.13.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -17073,19 +17087,39 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/model@5.0.0(@babel/core@7.28.0)(@ember-data/debug@5.0.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0)':
+  '@ember-data/model@5.0.0(@babel/core@7.24.3)(@ember-data/debug@5.0.0(@ember/string@3.1.1))(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))':
     dependencies:
-      '@ember-data/debug': 5.0.0(@ember/string@3.1.1)
-      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
-      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
       '@ember-data/legacy-compat': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)
       '@ember-data/private-build-infra': 5.0.0
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember-data/tracking': 5.0.0
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.15.0
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(ember-source@5.0.0)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.3)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
+      ember-cli-babel: 7.26.11
+      ember-cli-string-utils: 1.1.0
+      ember-cli-test-info: 1.0.0
+      ember-inflector: 4.0.2
+      inflection: 2.0.1
+    optionalDependencies:
+      '@ember-data/debug': 5.0.0(@ember/string@3.1.1)
+      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
+      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - ember-source
+      - supports-color
+
+  '@ember-data/model@5.0.0(@babel/core@7.24.3)(@ember-data/store@5.0.0)(@ember/string@4.0.1)(ember-inflector@4.0.2)(ember-source@3.27.5(@babel/core@7.24.3))':
+    dependencies:
+      '@ember-data/private-build-infra': 5.0.0
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3))
+      '@ember/edition-utils': 1.2.0
+      '@ember/string': 4.0.1
+      '@embroider/macros': 1.15.0
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
@@ -17096,13 +17130,14 @@ snapshots:
       - '@glint/template'
       - ember-source
       - supports-color
+    optional: true
 
-  '@ember-data/private-build-infra@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/private-build-infra@3.28.13(@babel/core@7.24.3)':
     dependencies:
-      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.24.3)
       '@ember-data/canary-features': 3.28.13
       '@ember/edition-utils': 1.2.0
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       babel-plugin-filter-imports: 4.0.0
       babel6-plugin-strip-class-callcheck: 6.0.0
       broccoli-debug: 0.6.5
@@ -17123,18 +17158,18 @@ snapshots:
       npm-git-info: 1.0.3
       rimraf: 3.0.2
       rsvp: 4.8.5
-      semver: 7.6.0
+      semver: 7.7.2
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/private-build-infra@4.7.3(@babel/core@7.28.0)':
+  '@ember-data/private-build-infra@4.7.3(@babel/core@7.24.3)':
     dependencies:
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.24.3)
       '@ember-data/canary-features': 4.7.3
       '@ember/edition-utils': 1.2.0
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       babel-plugin-filter-imports: 4.0.0
       babel6-plugin-strip-class-callcheck: 6.0.0
       broccoli-debug: 0.6.5
@@ -17184,17 +17219,17 @@ snapshots:
       ember-cli-version-checker: 5.1.2
       git-repo-info: 2.1.1
       npm-git-info: 1.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/record-data@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/record-data@3.28.13(@babel/core@7.24.3)':
     dependencies:
       '@ember-data/canary-features': 3.28.13
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/store': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/store': 3.28.13(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -17203,11 +17238,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/record-data@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/record-data@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
       '@ember-data/canary-features': 4.7.3
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
-      '@ember-data/store': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
+      '@ember-data/store': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       '@ember/edition-utils': 1.2.0
       ember-auto-import: 2.7.2(webpack@5.81.0)
       ember-cli-babel: 7.26.11
@@ -17231,10 +17266,10 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/serializer@3.28.13(@babel/core@7.24.3)':
     dependencies:
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/store': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/store': 3.28.13(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
       ember-cli-typescript: 4.2.1
@@ -17242,10 +17277,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/serializer@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/serializer@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
-      '@ember-data/store': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
+      '@ember-data/store': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       ember-auto-import: 2.7.2(webpack@5.81.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
@@ -17256,10 +17291,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/serializer@5.0.0(@ember-data/store@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)':
+  '@ember-data/serializer@5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)))(@ember/string@3.1.1)(ember-inflector@4.0.2)':
     dependencies:
       '@ember-data/private-build-infra': 5.0.0
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember/string': 3.1.1
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
@@ -17269,13 +17304,27 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/store@3.28.13(@babel/core@7.28.0)':
+  '@ember-data/serializer@5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3)))(@ember/string@4.0.1)(ember-inflector@4.0.2)':
+    dependencies:
+      '@ember-data/private-build-infra': 5.0.0
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3))
+      '@ember/string': 4.0.1
+      '@embroider/macros': 1.15.0
+      ember-cli-babel: 7.26.11
+      ember-cli-test-info: 1.0.0
+      ember-inflector: 4.0.2
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+    optional: true
+
+  '@ember-data/store@3.28.13(@babel/core@7.24.3)':
     dependencies:
       '@ember-data/canary-features': 3.28.13
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
       '@ember/string': 3.1.1
       '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.28.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-path-utils: 1.0.0
       ember-cli-typescript: 4.2.1
@@ -17283,15 +17332,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@ember-data/store@4.7.3(@babel/core@7.28.0)(webpack@5.81.0)':
+  '@ember-data/store@4.7.3(@babel/core@7.24.3)(webpack@5.81.0)':
     dependencies:
       '@ember-data/canary-features': 4.7.3
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
       '@ember/string': 3.1.1
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
       ember-auto-import: 2.7.2(webpack@5.81.0)
-      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.28.0)
+      ember-cached-decorator-polyfill: 0.1.4(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-path-utils: 1.0.0
       ember-cli-typescript: 5.2.1
@@ -17301,24 +17350,42 @@ snapshots:
       - supports-color
       - webpack
 
-  '@ember-data/store@5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)':
+  '@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))':
     dependencies:
-      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
-      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
-      '@ember-data/legacy-compat': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)
-      '@ember-data/model': 5.0.0(@babel/core@7.28.0)(@ember-data/debug@5.0.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0)
       '@ember-data/private-build-infra': 5.0.0
       '@ember-data/tracking': 5.0.0
       '@ember/string': 3.1.1
       '@embroider/macros': 1.15.0
       '@glimmer/tracking': 1.1.2
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.28.0)(ember-source@5.0.0)
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.3)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-cli-babel: 7.26.11
+    optionalDependencies:
+      '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
+      '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
+      '@ember-data/legacy-compat': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)
+      '@ember-data/model': 5.0.0(@babel/core@7.24.3)(@ember-data/debug@5.0.0(@ember/string@3.1.1))(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - ember-source
       - supports-color
+
+  '@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3))':
+    dependencies:
+      '@ember-data/private-build-infra': 5.0.0
+      '@ember/string': 4.0.1
+      '@embroider/macros': 1.15.0
+      '@glimmer/tracking': 1.1.2
+      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
+      ember-cli-babel: 7.26.11
+    optionalDependencies:
+      '@ember-data/model': 5.0.0(@babel/core@7.24.3)(@ember-data/store@5.0.0)(@ember/string@4.0.1)(ember-inflector@4.0.2)(ember-source@3.27.5(@babel/core@7.24.3))
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - ember-source
+      - supports-color
+    optional: true
 
   '@ember-data/tracking@5.0.0':
     dependencies:
@@ -17366,50 +17433,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/render-modifiers@1.0.2(@babel/core@7.28.0)':
+  '@ember/render-modifiers@1.0.2(@babel/core@7.24.3)':
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
+      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.24.3)(ember-source@3.27.5)':
+  '@ember/render-modifiers@2.1.0(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))':
     dependencies:
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  '@ember/render-modifiers@2.1.0(@babel/core@7.24.3)(ember-source@4.8.4)':
+  '@ember/render-modifiers@2.1.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))':
     dependencies:
       '@embroider/macros': 1.15.0
       ember-cli-babel: 7.26.11
       ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  '@ember/render-modifiers@2.1.0(@babel/core@7.28.0)(ember-source@3.27.5)':
-    dependencies:
-      '@embroider/macros': 1.15.0
-      ember-cli-babel: 7.26.11
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
-      ember-source: 3.27.5(@babel/core@7.28.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  '@ember/render-modifiers@2.1.0(@babel/core@7.28.0)(ember-source@4.8.4)':
-    dependencies:
-      '@embroider/macros': 1.15.0
-      ember-cli-babel: 7.26.11
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -17428,40 +17475,39 @@ snapshots:
 
   '@ember/string@4.0.1': {}
 
-  '@ember/test-helpers@2.9.3(@babel/core@7.28.0)(ember-source@3.27.5)':
-    dependencies:
-      '@ember/test-waiters': 3.1.0
-      '@embroider/macros': 1.15.0
-      '@embroider/util': 1.12.1(ember-source@3.27.5)
-      broccoli-debug: 0.6.5
-      broccoli-funnel: 3.0.8
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 6.3.0
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-source: 3.27.5(@babel/core@7.28.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/environment-ember-loose'
-      - '@glint/template'
-      - supports-color
-
-  '@ember/test-helpers@2.9.3(@babel/core@7.28.0)(ember-source@4.8.4)':
+  '@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))':
     dependencies:
       '@ember/test-waiters': 3.0.2
       '@embroider/macros': 1.10.0
-      '@embroider/util': 1.10.0(ember-source@4.8.4)
+      '@embroider/util': 1.10.0(ember-source@3.27.5(@babel/core@7.24.3))
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.2.0
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
       - supports-color
 
-  '@ember/test-helpers@3.0.3(ember-source@5.0.0)(webpack@5.89.0)':
+  '@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))':
+    dependencies:
+      '@ember/test-waiters': 3.0.2
+      '@embroider/macros': 1.10.0
+      '@embroider/util': 1.10.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.2.0
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+
+  '@ember/test-helpers@3.0.3(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0)':
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/macros': 1.13.4
@@ -17470,7 +17516,7 @@ snapshots:
       ember-auto-import: 2.6.3(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -17603,7 +17649,7 @@ snapshots:
       find-up: 5.0.0
       lodash: 4.17.21
       resolve: 1.22.8
-      semver: 7.6.0
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17642,7 +17688,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       typescript-memoize: 1.1.1
 
   '@embroider/shared-internals@2.0.0':
@@ -17665,7 +17711,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       typescript-memoize: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -17679,7 +17725,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       typescript-memoize: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -17729,39 +17775,39 @@ snapshots:
       lodash: 4.17.21
       resolve: 1.22.2
 
-  '@embroider/util@1.10.0(ember-source@4.8.4)':
+  '@embroider/util@1.10.0(ember-source@3.27.5(@babel/core@7.24.3))':
     dependencies:
       '@embroider/macros': 1.10.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/util@1.12.1(ember-source@3.27.5)':
+  '@embroider/util@1.10.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))':
+    dependencies:
+      '@embroider/macros': 1.10.0
+      broccoli-funnel: 3.0.8
+      ember-cli-babel: 7.26.11
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/util@1.12.1(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))':
     dependencies:
       '@embroider/macros': 1.15.0
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/util@1.12.1(ember-source@4.8.4)':
-    dependencies:
-      '@embroider/macros': 1.15.0
-      broccoli-funnel: 3.0.8
-      ember-cli-babel: 7.26.11
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@embroider/util@1.13.4(ember-source@3.27.5)':
+  '@embroider/util@1.13.4(ember-source@3.27.5(@babel/core@7.24.3))':
     dependencies:
       '@embroider/macros': 1.18.1
       broccoli-funnel: 3.0.8
       ember-cli-babel: 7.26.11
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -17837,7 +17883,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@glimmer/component@1.1.2(@babel/core@7.28.0)':
+  '@glimmer/component@1.1.2(@babel/core@7.24.3)':
     dependencies:
       '@glimmer/di': 0.1.11
       '@glimmer/env': 0.1.7
@@ -17850,9 +17896,9 @@ snapshots:
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-cli-typescript: 3.0.0(@babel/core@7.28.0)
+      ember-cli-typescript: 3.0.0(@babel/core@7.24.3)
       ember-cli-version-checker: 3.1.3
-      ember-compatibility-helpers: 1.2.6(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -17989,9 +18035,9 @@ snapshots:
       '@glimmer/env': 0.1.7
       '@glimmer/global-context': 0.84.3
 
-  '@glimmer/vm-babel-plugins@0.78.2(@babel/core@7.28.0)':
+  '@glimmer/vm-babel-plugins@0.78.2(@babel/core@7.24.3)':
     dependencies:
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -18001,9 +18047,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  '@glimmer/vm-babel-plugins@0.84.2(@babel/core@7.28.0)':
+  '@glimmer/vm-babel-plugins@0.84.2(@babel/core@7.24.3)':
     dependencies:
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
 
@@ -18063,7 +18109,7 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@jimp/bmp@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/bmp@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
@@ -18093,184 +18139,184 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@jimp/gif@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/gif@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
       omggif: 1.0.10
 
-  '@jimp/jpeg@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/jpeg@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
       jpeg-js: 0.3.7
 
-  '@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-blur@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/plugin-blur@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-color@0.5.5(@jimp/custom@0.5.4)':
+  '@jimp/plugin-color@0.5.5(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
       tinycolor2: 1.6.0
 
-  '@jimp/plugin-contain@0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(@jimp/plugin-resize@0.5.4)(@jimp/plugin-scale@0.5.0)':
+  '@jimp/plugin-contain@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-resize@0.5.4)
+      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-cover@0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-crop@0.5.4)(@jimp/plugin-resize@0.5.4)(@jimp/plugin-scale@0.5.0)':
+  '@jimp/plugin-cover@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-resize@0.5.4)
+      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4)':
-    dependencies:
-      '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/utils': 0.5.0
-      core-js: 2.6.12
-
-  '@jimp/plugin-displace@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-dither@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/plugin-displace@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-flip@0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-rotate@0.5.4)':
-    dependencies:
-      '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-rotate': 0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(@jimp/plugin-crop@0.5.4)(@jimp/plugin-resize@0.5.4)
-      '@jimp/utils': 0.5.0
-      core-js: 2.6.12
-
-  '@jimp/plugin-gaussian@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/plugin-dither@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-invert@0.5.0(@jimp/custom@0.5.4)':
+  '@jimp/plugin-flip@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-rotate@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))':
+    dependencies:
+      '@jimp/custom': 0.5.4(debug@4.3.2)
+      '@jimp/plugin-rotate': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))
+      '@jimp/utils': 0.5.0
+      core-js: 2.6.12
+
+  '@jimp/plugin-gaussian@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-mask@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/plugin-invert@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-normalize@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/plugin-mask@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-print@0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(debug@4.3.2)':
+  '@jimp/plugin-normalize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/utils': 0.5.0
+      core-js: 2.6.12
+
+  '@jimp/plugin-print@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(debug@4.3.2)':
+    dependencies:
+      '@jimp/custom': 0.5.4(debug@4.3.2)
+      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
       load-bmfont: 1.4.2(debug@4.3.2)
     transitivePeerDependencies:
       - debug
 
-  '@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-rotate@0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(@jimp/plugin-crop@0.5.4)(@jimp/plugin-resize@0.5.4)':
+  '@jimp/plugin-rotate@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-resize@0.5.4)':
+  '@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
 
-  '@jimp/plugins@0.5.5(@jimp/custom@0.5.4)(debug@4.3.2)':
+  '@jimp/plugins@0.5.5(@jimp/custom@0.5.4(debug@4.3.2))(debug@4.3.2)':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-blur': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/plugin-color': 0.5.5(@jimp/custom@0.5.4)
-      '@jimp/plugin-contain': 0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(@jimp/plugin-resize@0.5.4)(@jimp/plugin-scale@0.5.0)
-      '@jimp/plugin-cover': 0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-crop@0.5.4)(@jimp/plugin-resize@0.5.4)(@jimp/plugin-scale@0.5.0)
-      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-displace': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/plugin-dither': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/plugin-flip': 0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-rotate@0.5.4)
-      '@jimp/plugin-gaussian': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/plugin-invert': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/plugin-mask': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-normalize': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-print': 0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(debug@4.3.2)
-      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/plugin-rotate': 0.5.4(@jimp/custom@0.5.4)(@jimp/plugin-blit@0.5.4)(@jimp/plugin-crop@0.5.4)(@jimp/plugin-resize@0.5.4)
-      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4)(@jimp/plugin-resize@0.5.4)
+      '@jimp/plugin-blit': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-blur': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-color': 0.5.5(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-contain': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))
+      '@jimp/plugin-cover': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-scale@0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))
+      '@jimp/plugin-crop': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-displace': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-dither': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-flip': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-rotate@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))))
+      '@jimp/plugin-gaussian': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-invert': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-mask': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-normalize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-print': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(debug@4.3.2)
+      '@jimp/plugin-resize': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/plugin-rotate': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-blit@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-crop@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))
+      '@jimp/plugin-scale': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))(@jimp/plugin-resize@0.5.4(@jimp/custom@0.5.4(debug@4.3.2)))
       core-js: 2.6.12
       timm: 1.7.1
     transitivePeerDependencies:
       - debug
 
-  '@jimp/png@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/png@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       '@jimp/utils': 0.5.0
       core-js: 2.6.12
       pngjs: 3.4.0
 
-  '@jimp/tiff@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/tiff@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
       '@jimp/custom': 0.5.4(debug@4.3.2)
       core-js: 2.6.12
       utif: 2.0.1
 
-  '@jimp/types@0.5.4(@jimp/custom@0.5.4)':
+  '@jimp/types@0.5.4(@jimp/custom@0.5.4(debug@4.3.2))':
     dependencies:
-      '@jimp/bmp': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/bmp': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/gif': 0.5.0(@jimp/custom@0.5.4)
-      '@jimp/jpeg': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/png': 0.5.4(@jimp/custom@0.5.4)
-      '@jimp/tiff': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/gif': 0.5.0(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/jpeg': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/png': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
+      '@jimp/tiff': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       core-js: 2.6.12
       timm: 1.7.1
 
@@ -18371,17 +18417,17 @@ snapshots:
 
   '@nullvoxpopuli/eslint-configs@2.2.14(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.21.0(@typescript-eslint/parser@5.21.0)(eslint@7.32.0)(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 5.21.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint@7.32.0)(typescript@5.9.2)
       '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
       babel-eslint: 10.1.0(eslint@7.32.0)
       eslint: 7.32.0
       eslint-config-prettier: 8.5.0(eslint@7.32.0)
       eslint-plugin-decorator-position: 4.0.1(eslint@7.32.0)
       eslint-plugin-ember: 10.6.0(eslint@7.32.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.21.0)(eslint@7.32.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint@7.32.0)
       eslint-plugin-json: 3.1.0
       eslint-plugin-node: 11.1.0(eslint@7.32.0)
-      eslint-plugin-prettier: 4.0.0(eslint-config-prettier@8.5.0)(eslint@7.32.0)(prettier@2.6.2)
+      eslint-plugin-prettier: 4.0.0(eslint-config-prettier@8.5.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.6.2)
       eslint-plugin-qunit: 7.2.0(eslint@7.32.0)
       eslint-plugin-simple-import-sort: 7.0.0(eslint@7.32.0)
       prettier: 2.6.2
@@ -18552,7 +18598,7 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       right-pad: 1.0.1
       rxjs: 7.8.1
-      semver: 7.6.0
+      semver: 7.7.2
       stacktracey: 2.1.8
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -18662,7 +18708,7 @@ snapshots:
       detect-libc: 2.0.3
       execa: safe-execa@0.1.2
       mem: 8.1.1
-      semver: 7.6.0
+      semver: 7.7.2
 
   '@pnpm/pnpmfile@5.0.7(@pnpm/logger@5.2.0)':
     dependencies:
@@ -18847,7 +18893,7 @@ snapshots:
       read-pkg: 5.2.0
       registry-auth-token: 5.0.2
       semantic-release: 19.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       tempy: 1.0.1
 
   '@semantic-release/release-notes-generator@10.0.3(semantic-release@19.0.3)':
@@ -18913,10 +18959,15 @@ snapshots:
     dependencies:
       defer-to-connect: 1.1.3
 
-  '@tailwindcss/forms@0.3.4(tailwindcss@2.2.19)':
+  '@tailwindcss/forms@0.3.4(tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.23))(postcss@8.4.23))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 2.2.19(autoprefixer@10.4.14)(postcss@8.4.23)
+      tailwindcss: 2.2.19(autoprefixer@10.4.14(postcss@8.4.23))(postcss@8.4.23)
+
+  '@tailwindcss/forms@0.3.4(tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.38))(postcss@8.4.38))':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 2.2.19(autoprefixer@10.4.14(postcss@8.4.38))(postcss@8.4.38)
 
   '@tootallnate/once@1.1.2': {}
 
@@ -19179,7 +19230,7 @@ snapshots:
 
   '@types/symlink-or-copy@1.2.0': {}
 
-  '@typescript-eslint/eslint-plugin@5.21.0(@typescript-eslint/parser@5.21.0)(eslint@7.32.0)(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@5.21.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint@7.32.0)(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 5.21.0
@@ -19190,8 +19241,9 @@ snapshots:
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
       regexpp: 3.2.0
-      semver: 7.6.0
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.9.2)
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -19203,6 +19255,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 5.21.0(typescript@5.9.2)
       debug: 4.3.2(supports-color@5.5.0)
       eslint: 7.32.0
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -19218,6 +19271,7 @@ snapshots:
       debug: 4.3.2(supports-color@5.5.0)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.9.2)
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -19231,8 +19285,9 @@ snapshots:
       debug: 4.3.2(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       tsutils: 3.21.0(typescript@5.9.2)
+    optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -19732,11 +19787,11 @@ snapshots:
       ajv: 6.12.6
 
   ajv-formats@2.1.1(ajv@8.12.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.12.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
-    dependencies:
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -20321,11 +20376,6 @@ snapshots:
   babel-plugin-debug-macros@0.2.0(@babel/core@7.24.3):
     dependencies:
       '@babel/core': 7.24.3
-      semver: 5.7.2
-
-  babel-plugin-debug-macros@0.2.0(@babel/core@7.28.0):
-    dependencies:
-      '@babel/core': 7.28.0
       semver: 5.7.2
 
   babel-plugin-debug-macros@0.3.4(@babel/core@7.17.10):
@@ -21760,7 +21810,7 @@ snapshots:
 
   builtins@5.0.1:
     dependencies:
-      semver: 7.6.0
+      semver: 7.7.2
 
   bytes@1.0.0: {}
 
@@ -22332,10 +22382,15 @@ snapshots:
       ora: 3.4.0
       through2: 3.0.2
 
-  consolidate@0.16.0(mustache@4.2.0):
+  consolidate@0.16.0(babel-core@6.26.3)(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(underscore@1.13.6):
     dependencies:
       bluebird: 3.7.2
+    optionalDependencies:
+      babel-core: 6.26.3
+      handlebars: 4.7.8
+      lodash: 4.17.21
       mustache: 4.2.0
+      underscore: 1.13.6
 
   constants-browserify@1.0.0: {}
 
@@ -22444,12 +22499,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6:
+  cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.9.2
 
   create-ecdh@4.0.4:
     dependencies:
@@ -22532,7 +22589,7 @@ snapshots:
       postcss-modules-scope: 3.0.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       semver: 7.6.0
       webpack: 5.101.0
 
@@ -22560,7 +22617,7 @@ snapshots:
       postcss-modules-scope: 3.0.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       semver: 7.6.0
       webpack: 5.89.0
 
@@ -22574,7 +22631,7 @@ snapshots:
       postcss-modules-scope: 3.0.0(postcss@8.4.38)
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       semver: 7.6.0
       webpack: 5.91.0
 
@@ -22703,11 +22760,13 @@ snapshots:
   debug@4.3.2(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 5.5.0
 
   debug@4.3.4(supports-color@9.4.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 9.4.0
 
   debug@4.4.1:
@@ -22736,9 +22795,9 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  decorator-transforms@2.3.0(@babel/core@7.28.0):
+  decorator-transforms@2.3.0(@babel/core@7.24.3):
     dependencies:
-      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.24.3)
       babel-import-util: 3.0.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -23022,15 +23081,15 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
-  ember-app-scheduler@7.0.1(@babel/core@7.28.0):
+  ember-app-scheduler@7.0.1(@babel/core@7.24.3):
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@types/ember': 3.16.7
       '@types/rsvp': 4.0.4
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 4.2.1
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -23220,7 +23279,7 @@ snapshots:
       parse5: 6.0.1
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       style-loader: 2.0.0(webpack@5.89.0)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
@@ -23257,7 +23316,7 @@ snapshots:
       parse5: 6.0.1
       resolve: 1.22.8
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
       style-loader: 2.0.0(webpack@5.91.0)
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
@@ -23270,7 +23329,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-decorators': 7.22.5(@babel/core@7.21.4)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.21.4)
       '@babel/preset-env': 7.21.4(@babel/core@7.21.4)
       '@embroider/macros': 1.10.0
       '@embroider/shared-internals': 2.0.0
@@ -23344,7 +23403,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-decorators': 7.22.5(@babel/core@7.21.4)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.21.4)
       '@babel/preset-env': 7.21.4(@babel/core@7.21.4)
       '@embroider/macros': 1.10.0
       '@embroider/shared-internals': 2.0.0
@@ -23381,7 +23440,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.21.4
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-decorators': 7.22.5(@babel/core@7.21.4)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.21.4)
       '@babel/preset-env': 7.21.4(@babel/core@7.21.4)
       '@embroider/macros': 1.10.0
       '@embroider/shared-internals': 2.0.0
@@ -23506,35 +23565,50 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.28.0):
+  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.24.3):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
       silent-error: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@0.1.4(@babel/core@7.28.0):
+  ember-cached-decorator-polyfill@0.1.4(@babel/core@7.24.3):
     dependencies:
       '@glimmer/tracking': 1.1.2
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.28.0)(ember-source@5.0.0):
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)):
     dependencies:
       '@embroider/macros': 1.15.0
       '@glimmer/tracking': 1.1.2
       babel-import-util: 1.4.1
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@glint/template'
+      - supports-color
+    optional: true
+
+  ember-cached-decorator-polyfill@1.0.2(@babel/core@7.24.3)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
+    dependencies:
+      '@embroider/macros': 1.15.0
+      '@glimmer/tracking': 1.1.2
+      babel-import-util: 1.4.1
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
+      ember-cli-babel: 7.26.11
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -23552,12 +23626,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-addon-docs@7.0.0(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(ember-data@4.7.3)(ember-fetch@8.1.2)(ember-source@4.8.4)(webpack@5.81.0):
+  ember-cli-addon-docs@7.0.0(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-data@4.7.3(@babel/core@7.24.3)(webpack@5.81.0))(ember-fetch@8.1.2)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0):
     dependencies:
       '@csstools/postcss-sass': 5.1.1(postcss@8.4.38)
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.28.0)(ember-source@4.8.4)
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       '@ember/test-waiters': 3.1.0
-      '@glimmer/component': 1.1.2(@babel/core@7.28.0)
+      '@glimmer/component': 1.1.2(@babel/core@7.24.3)
       '@glimmer/syntax': 0.86.0
       '@glimmer/tracking': 1.1.2
       '@handlebars/parser': 2.1.0
@@ -23574,7 +23648,7 @@ snapshots:
       ember-auto-import: 2.7.2(webpack@5.81.0)
       ember-cli-autoprefixer: 2.0.0
       ember-cli-babel: 7.26.11
-      ember-cli-clipboard: 1.1.0(ember-source@4.8.4)(webpack@5.81.0)
+      ember-cli-clipboard: 1.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
       ember-cli-htmlbars: 6.3.0
       ember-cli-postcss: 8.2.0
       ember-cli-string-helpers: 6.1.0
@@ -23582,19 +23656,19 @@ snapshots:
       ember-cli-version-checker: 5.1.2
       ember-code-snippet: 3.0.0
       ember-composable-helpers: 5.0.0
-      ember-concurrency: 3.1.1(@babel/core@7.28.0)(ember-source@4.8.4)
-      ember-data: 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      ember-concurrency: 3.1.1(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-data: 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       ember-fetch: 8.1.2
-      ember-keyboard: 8.2.1(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(ember-source@4.8.4)
-      ember-modal-dialog: 4.1.3(ember-source@4.8.4)(ember-tether@3.1.0)
+      ember-keyboard: 8.2.1(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-modal-dialog: 4.1.3(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(ember-tether@3.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0))
       ember-responsive: 5.0.0
       ember-router-generator: 2.0.0
-      ember-router-scroll: 4.1.2(@babel/core@7.28.0)
+      ember-router-scroll: 4.1.2(@babel/core@7.24.3)
       ember-set-helper: 2.0.1
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
       ember-svg-jar: 2.4.9
-      ember-tether: 3.1.0(ember-source@4.8.4)(webpack@5.81.0)
-      ember-truth-helpers: 4.0.3(ember-source@4.8.4)
+      ember-tether: 3.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
+      ember-truth-helpers: 4.0.3(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       esm: 3.2.25
       execa: 5.1.1
       fs-extra: 11.1.1
@@ -23620,7 +23694,7 @@ snapshots:
       semver: 7.6.0
       striptags: 3.2.0
       tailwindcss: 1.9.6
-      tracked-toolbox: 2.0.0(@babel/core@7.28.0)(ember-source@4.8.4)
+      tracked-toolbox: 2.0.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       walk-sync: 3.0.0
       yuidocjs: 0.10.2
     transitivePeerDependencies:
@@ -23634,14 +23708,13 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  ember-cli-addon-docs@https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d(@babel/core@7.28.0)(@ember/string@4.0.1)(@ember/test-helpers@2.9.3)(ember-data@3.28.13)(ember-source@3.27.5)(webpack@5.91.0):
-    id: ember-cli-addon-docs@https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d
+  ember-cli-addon-docs@https://codeload.github.com/ember-learn/ember-cli-addon-docs/tar.gz/cd2bdc2319ef793575e1c22e7ba47ffef7d6975d(giiqxtp36gcmbqr7jn4efnbz7u):
     dependencies:
       '@csstools/postcss-sass': 5.1.1(postcss@8.5.6)
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.28.0)(ember-source@3.27.5)
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       '@ember/string': 4.0.1
       '@ember/test-waiters': 3.1.0
-      '@glimmer/component': 1.1.2(@babel/core@7.28.0)
+      '@glimmer/component': 1.1.2(@babel/core@7.24.3)
       '@glimmer/syntax': 0.87.1
       '@glimmer/tracking': 1.1.2
       '@handlebars/parser': 2.2.1
@@ -23657,25 +23730,25 @@ snapshots:
       chalk: 4.1.2
       ember-auto-import: 2.10.0(webpack@5.91.0)
       ember-cli-autoprefixer: 2.0.0
-      ember-cli-babel: 8.2.0(@babel/core@7.28.0)
-      ember-cli-clipboard: 1.3.0(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(webpack@5.91.0)
+      ember-cli-babel: 8.2.0(@babel/core@7.24.3)
+      ember-cli-clipboard: 1.3.0(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)))(webpack@5.91.0)
       ember-cli-htmlbars: 6.3.0
       ember-cli-postcss: 8.2.0
       ember-cli-string-utils: 1.1.0
       ember-cli-version-checker: 5.1.2
       ember-code-snippet: 3.0.0
       ember-composable-helpers: 5.0.0
-      ember-concurrency: 3.1.1(@babel/core@7.28.0)(ember-source@3.27.5)
-      ember-data: 3.28.13(@babel/core@7.28.0)
-      ember-keyboard: 9.0.2(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)
-      ember-modal-dialog: 4.1.5(@ember/string@4.0.1)(ember-source@3.27.5)(ember-tether@3.1.0)
+      ember-concurrency: 3.1.1(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
+      ember-data: 3.28.13(@babel/core@7.24.3)
+      ember-keyboard: 9.0.2(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)))
+      ember-modal-dialog: 4.1.5(@ember/string@4.0.1)(ember-source@3.27.5(@babel/core@7.24.3))(ember-tether@3.1.0(ember-source@3.27.5(@babel/core@7.24.3))(webpack@5.91.0))
       ember-router-generator: 2.0.0
-      ember-router-scroll: 4.1.2(@babel/core@7.28.0)
+      ember-router-scroll: 4.1.2(@babel/core@7.24.3)
       ember-set-helper: 2.0.1
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
       ember-svg-jar: 2.6.3
-      ember-tether: 3.1.0(ember-source@3.27.5)(webpack@5.91.0)
-      ember-truth-helpers: 4.0.3(ember-source@3.27.5)
+      ember-tether: 3.1.0(ember-source@3.27.5(@babel/core@7.24.3))(webpack@5.91.0)
+      ember-truth-helpers: 4.0.3(ember-source@3.27.5(@babel/core@7.24.3))
       esm: 3.2.25
       execa: 5.1.1
       fs-extra: 11.3.1
@@ -23701,9 +23774,15 @@ snapshots:
       semver: 7.7.2
       striptags: 3.2.0
       tailwindcss: 1.9.6
-      tracked-toolbox: 2.0.0(@babel/core@7.28.0)(ember-source@3.27.5)
+      tracked-toolbox: 2.0.0(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       walk-sync: 3.0.0
       yuidocjs: 0.10.2
+    optionalDependencies:
+      '@ember-data/adapter': 5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3)))(@ember/string@4.0.1)(ember-inflector@4.0.2)
+      '@ember-data/model': 5.0.0(@babel/core@7.24.3)(@ember-data/store@5.0.0)(@ember/string@4.0.1)(ember-inflector@4.0.2)(ember-source@3.27.5(@babel/core@7.24.3))
+      '@ember-data/serializer': 5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3)))(@ember/string@4.0.1)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/model@5.0.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(ember-source@3.27.5(@babel/core@7.24.3))
+      ember-inflector: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@ember/test-helpers'
@@ -23724,10 +23803,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-app-version@6.0.0(ember-source@5.0.0):
+  ember-cli-app-version@6.0.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
       git-repo-info: 2.1.1
     transitivePeerDependencies:
       - supports-color
@@ -23741,10 +23820,10 @@ snapshots:
 
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
-  ember-cli-babel@6.18.0(@babel/core@7.28.0):
+  ember-cli-babel@6.18.0(@babel/core@7.24.3):
     dependencies:
       amd-name-resolver: 1.2.0
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.2.0(@babel/core@7.24.3)
       babel-plugin-ember-modules-api-polyfill: 2.13.4
       babel-plugin-transform-es2015-modules-amd: 6.24.1
       babel-polyfill: 6.26.0
@@ -23850,7 +23929,7 @@ snapshots:
       ember-cli-version-checker: 5.1.2
       ensure-posix-path: 1.1.1
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23883,7 +23962,7 @@ snapshots:
       ember-cli-version-checker: 5.1.2
       ensure-posix-path: 1.1.1
       resolve-package-path: 4.0.3
-      semver: 7.6.0
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -23911,7 +23990,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-clipboard@1.1.0(ember-source@4.8.4)(webpack@5.81.0):
+  ember-cli-clipboard@1.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0):
     dependencies:
       '@embroider/macros': 1.15.0
       clipboard: 2.0.11
@@ -23919,7 +23998,7 @@ snapshots:
       ember-auto-import: 2.6.3(webpack@5.81.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.1.0(ember-source@4.8.4)
+      ember-modifier: 4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       prop-types: 15.8.1
     transitivePeerDependencies:
       - '@glint/template'
@@ -23927,16 +24006,16 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-cli-clipboard@1.3.0(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(webpack@5.91.0):
+  ember-cli-clipboard@1.3.0(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)))(webpack@5.91.0):
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.28.0)(ember-source@3.27.5)
+      '@ember/test-helpers': 2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       '@embroider/macros': 1.18.1
       clipboard: 2.0.11
       ember-arg-types: 1.1.0(webpack@5.91.0)
       ember-auto-import: 2.10.0(webpack@5.91.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.2.2(@babel/core@7.28.0)
+      ember-modifier: 4.2.2(@babel/core@7.24.3)
       prop-types: 15.8.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -23958,9 +24037,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-custom-assertions@0.2.0(@babel/core@7.28.0):
+  ember-cli-custom-assertions@0.2.0(@babel/core@7.24.3):
     dependencies:
-      ember-cli-babel: 6.18.0(@babel/core@7.28.0)
+      ember-cli-babel: 6.18.0(@babel/core@7.24.3)
       ember-cli-string-utils: 1.1.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -23973,10 +24052,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.1(ember-cli@3.27.0):
+  ember-cli-dependency-checker@3.3.1(ember-cli@3.27.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 3.27.0(debug@4.3.2)
+      ember-cli: 3.27.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.2
@@ -23984,10 +24063,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.1(ember-cli@4.8.0):
+  ember-cli-dependency-checker@3.3.1(ember-cli@4.8.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 4.8.0(debug@4.3.2)
+      ember-cli: 4.8.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.2
@@ -23995,10 +24074,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.1(ember-cli@5.0.0):
+  ember-cli-dependency-checker@3.3.1(ember-cli@5.0.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 5.0.0(debug@4.3.2)
+      ember-cli: 5.0.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.2
@@ -24019,9 +24098,9 @@ snapshots:
       execa: 0.7.0
       fs-extra: 4.0.3
 
-  ember-cli-deploy-git@1.3.4(@babel/core@7.28.0):
+  ember-cli-deploy-git@1.3.4(@babel/core@7.24.3):
     dependencies:
-      ember-cli-babel: 6.18.0(@babel/core@7.28.0)
+      ember-cli-babel: 6.18.0(@babel/core@7.24.3)
       ember-cli-deploy-plugin: 0.2.9
       fs-extra: 5.0.0
       rsvp: 4.8.5
@@ -24243,10 +24322,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-typescript@2.0.2(@babel/core@7.28.0):
+  ember-cli-typescript@2.0.2(@babel/core@7.24.3):
     dependencies:
-      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.28.0)
-      '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.28.0)
+      '@babel/plugin-proposal-class-properties': 7.16.7(@babel/core@7.24.3)
+      '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.24.3)
       ansi-to-html: 0.6.15
       debug: 4.3.2(supports-color@5.5.0)
       ember-cli-babel-plugin-helpers: 1.1.1
@@ -24278,9 +24357,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cli-typescript@3.0.0(@babel/core@7.28.0):
+  ember-cli-typescript@3.0.0(@babel/core@7.24.3):
     dependencies:
-      '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.24.3)
       ansi-to-html: 0.6.15
       debug: 4.3.2(supports-color@5.5.0)
       ember-cli-babel-plugin-helpers: 1.1.1
@@ -24295,11 +24374,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cli-typescript@3.1.4(@babel/core@7.28.0):
+  ember-cli-typescript@3.1.4(@babel/core@7.24.3):
     dependencies:
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.28.0)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.28.0)
-      '@babel/plugin-transform-typescript': 7.8.7(@babel/core@7.28.0)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.3)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.3)
+      '@babel/plugin-transform-typescript': 7.8.7(@babel/core@7.24.3)
       ansi-to-html: 0.6.15
       broccoli-stew: 3.0.0
       debug: 4.3.2(supports-color@5.5.0)
@@ -24386,7 +24465,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@3.27.0(debug@4.3.2):
+  ember-cli@3.27.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6):
     dependencies:
       '@babel/core': 7.24.3
       '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.24.3)
@@ -24471,7 +24550,7 @@ snapshots:
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.10.1(debug@4.3.2)
+      testem: 3.10.1(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       uuid: 8.3.2
@@ -24538,7 +24617,7 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-cli@4.8.0(debug@4.3.2):
+  ember-cli@4.8.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6):
     dependencies:
       '@babel/core': 7.21.5
       '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.21.5)
@@ -24624,7 +24703,7 @@ snapshots:
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.10.1(debug@4.3.2)
+      testem: 3.10.1(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       uuid: 8.3.2
@@ -24691,7 +24770,7 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-cli@5.0.0(debug@4.3.2):
+  ember-cli@5.0.0(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6):
     dependencies:
       '@babel/core': 7.23.7
       broccoli: 3.5.2
@@ -24771,7 +24850,7 @@ snapshots:
       sort-package-json: 1.57.0
       symlink-or-copy: 1.3.1
       temp: 0.9.4
-      testem: 3.10.1(debug@4.3.2)
+      testem: 3.10.1(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6)
       tiny-lr: 2.0.0
       tree-sync: 2.1.0
       uuid: 9.0.1
@@ -24860,9 +24939,9 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-compatibility-helpers@1.2.6(@babel/core@7.28.0):
+  ember-compatibility-helpers@1.2.6(@babel/core@7.24.3):
     dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.2.0(@babel/core@7.24.3)
       ember-cli-version-checker: 5.1.2
       find-up: 5.0.0
       fs-extra: 9.1.0
@@ -24885,17 +24964,6 @@ snapshots:
   ember-compatibility-helpers@1.2.7(@babel/core@7.24.3):
     dependencies:
       babel-plugin-debug-macros: 0.2.0(@babel/core@7.24.3)
-      ember-cli-version-checker: 5.1.2
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      semver: 5.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  ember-compatibility-helpers@1.2.7(@babel/core@7.28.0):
-    dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.28.0)
       ember-cli-version-checker: 5.1.2
       find-up: 5.0.0
       fs-extra: 9.1.0
@@ -24936,7 +25004,7 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-concurrency@2.3.7(@babel/core@7.28.0):
+  ember-concurrency@2.3.7(@babel/core@7.24.3):
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/types': 7.21.5
@@ -24944,13 +25012,13 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-cli-htmlbars: 5.7.2
-      ember-compatibility-helpers: 1.2.6(@babel/core@7.28.0)
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.6(@babel/core@7.24.3)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.28.0)(ember-source@3.27.5):
+  ember-concurrency@3.1.1(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)):
     dependencies:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/types': 7.24.0
@@ -24958,13 +25026,13 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-cli-htmlbars: 6.3.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-concurrency@3.1.1(@babel/core@7.28.0)(ember-source@4.8.4):
+  ember-concurrency@3.1.1(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/types': 7.24.0
@@ -24972,21 +25040,21 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-cli-babel-plugin-helpers: 1.1.1
       ember-cli-htmlbars: 6.3.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-data@3.28.13(@babel/core@7.28.0):
+  ember-data@3.28.13(@babel/core@7.24.3):
     dependencies:
-      '@ember-data/adapter': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/debug': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/model': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/record-data': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/serializer': 3.28.13(@babel/core@7.28.0)
-      '@ember-data/store': 3.28.13(@babel/core@7.28.0)
+      '@ember-data/adapter': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/debug': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/model': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/private-build-infra': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/record-data': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/serializer': 3.28.13(@babel/core@7.24.3)
+      '@ember-data/store': 3.28.13(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
       '@glimmer/env': 0.1.7
@@ -24998,15 +25066,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-data@4.7.3(@babel/core@7.28.0)(webpack@5.81.0):
+  ember-data@4.7.3(@babel/core@7.24.3)(webpack@5.81.0):
     dependencies:
-      '@ember-data/adapter': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
-      '@ember-data/debug': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
-      '@ember-data/model': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
-      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.28.0)
-      '@ember-data/record-data': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
-      '@ember-data/serializer': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
-      '@ember-data/store': 4.7.3(@babel/core@7.28.0)(webpack@5.81.0)
+      '@ember-data/adapter': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
+      '@ember-data/debug': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
+      '@ember-data/model': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
+      '@ember-data/private-build-infra': 4.7.3(@babel/core@7.24.3)
+      '@ember-data/record-data': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
+      '@ember-data/serializer': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
+      '@ember-data/store': 4.7.3(@babel/core@7.24.3)(webpack@5.81.0)
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.0.1
       '@embroider/macros': 1.10.0
@@ -25022,18 +25090,18 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-data@5.0.0(@babel/core@7.28.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0):
+  ember-data@5.0.0(@babel/core@7.24.3)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
     dependencies:
-      '@ember-data/adapter': 5.0.0(@ember-data/store@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)
+      '@ember-data/adapter': 5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)))(@ember/string@3.1.1)(ember-inflector@4.0.2)
       '@ember-data/debug': 5.0.0(@ember/string@3.1.1)
       '@ember-data/graph': 5.0.0(@ember-data/store@5.0.0)
       '@ember-data/json-api': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/store@5.0.0)
       '@ember-data/legacy-compat': 5.0.0(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)
-      '@ember-data/model': 5.0.0(@babel/core@7.28.0)(@ember-data/debug@5.0.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0)
+      '@ember-data/model': 5.0.0(@babel/core@7.24.3)(@ember-data/debug@5.0.0(@ember/string@3.1.1))(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/store@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember-data/private-build-infra': 5.0.0
       '@ember-data/request': 5.0.0
-      '@ember-data/serializer': 5.0.0(@ember-data/store@5.0.0)(@ember/string@3.1.1)(ember-inflector@4.0.2)
-      '@ember-data/store': 5.0.0(@babel/core@7.28.0)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0)
+      '@ember-data/serializer': 5.0.0(@ember-data/store@5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)))(@ember/string@3.1.1)(ember-inflector@4.0.2)
+      '@ember-data/store': 5.0.0(@babel/core@7.24.3)(@ember-data/graph@5.0.0)(@ember-data/json-api@5.0.0)(@ember-data/legacy-compat@5.0.0)(@ember-data/model@5.0.0)(@ember-data/tracking@5.0.0)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       '@ember-data/tracking': 5.0.0
       '@ember/edition-utils': 1.2.0
       '@ember/string': 3.1.1
@@ -25078,11 +25146,11 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-destroyable-polyfill@2.0.3(@babel/core@7.28.0):
+  ember-destroyable-polyfill@2.0.3(@babel/core@7.24.3):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -25128,21 +25196,21 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  ember-functions-as-helper-polyfill@2.1.2(ember-source@3.27.5):
+  ember-functions-as-helper-polyfill@2.1.2(ember-source@3.27.5(@babel/core@7.24.3)):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - supports-color
 
-  ember-functions-as-helper-polyfill@2.1.2(ember-source@4.8.4):
+  ember-functions-as-helper-polyfill@2.1.2(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
       ember-cli-version-checker: 5.1.2
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25155,25 +25223,25 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-gesture-modifiers@5.0.1(ember-source@4.8.4)(webpack@5.81.0):
+  ember-gesture-modifiers@5.0.1(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0):
     dependencies:
       ember-auto-import: 2.7.2(webpack@5.81.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.1.0(ember-source@4.8.4)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-modifier: 4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-gesture-modifiers@5.0.1(ember-source@5.0.0)(webpack@5.89.0):
+  ember-gesture-modifiers@5.0.1(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0):
     dependencies:
       ember-auto-import: 2.7.2(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-modifier: 4.1.0(ember-source@5.0.0)
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-modifier: 4.1.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
@@ -25199,74 +25267,78 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-keyboard@8.2.1(@babel/core@7.28.0)(@ember/test-helpers@2.9.3)(ember-source@4.8.4):
+  ember-keyboard@8.2.1(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.28.0)(ember-source@4.8.4)
       '@embroider/addon-shim': 1.8.7
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-modifier: 4.1.0(ember-source@4.8.4)
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
+      ember-modifier: 4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
+    optionalDependencies:
+      '@ember/test-helpers': 2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
     transitivePeerDependencies:
       - '@babel/core'
       - ember-source
       - supports-color
 
-  ember-keyboard@9.0.2(@babel/core@7.28.0)(@ember/test-helpers@2.9.3):
+  ember-keyboard@9.0.2(@babel/core@7.24.3)(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))):
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.28.0)(ember-source@3.27.5)
       '@embroider/addon-shim': 1.10.0
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-modifier: 2.1.2(@babel/core@7.28.0)
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
+      ember-modifier: 2.1.2(@babel/core@7.24.3)
+      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
+    optionalDependencies:
+      '@ember/test-helpers': 2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-load-initializers@2.1.2(@babel/core@7.28.0):
+  ember-load-initializers@2.1.2(@babel/core@7.24.3):
     dependencies:
       ember-cli-babel: 7.26.11
-      ember-cli-typescript: 2.0.2(@babel/core@7.28.0)
+      ember-cli-typescript: 2.0.2(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-maybe-import-regenerator@0.1.6(@babel/core@7.28.0):
+  ember-maybe-import-regenerator@0.1.6(@babel/core@7.24.3):
     dependencies:
       broccoli-funnel: 1.2.0
       broccoli-merge-trees: 1.2.4
-      ember-cli-babel: 6.18.0(@babel/core@7.28.0)
+      ember-cli-babel: 6.18.0(@babel/core@7.24.3)
       regenerator-runtime: 0.9.6
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-modal-dialog@4.1.3(ember-source@4.8.4)(ember-tether@3.1.0):
+  ember-modal-dialog@4.1.3(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(ember-tether@3.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)):
     dependencies:
       '@embroider/macros': 1.15.0
-      '@embroider/util': 1.12.1(ember-source@4.8.4)
+      '@embroider/util': 1.12.1(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
       ember-cli-version-checker: 2.2.0
       ember-decorators: 6.1.1
-      ember-tether: 3.1.0(ember-source@4.8.4)(webpack@5.81.0)
       ember-wormhole: 0.6.0
+    optionalDependencies:
+      ember-tether: 3.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
     transitivePeerDependencies:
       - '@glint/environment-ember-loose'
       - '@glint/template'
       - ember-source
       - supports-color
 
-  ember-modal-dialog@4.1.5(@ember/string@4.0.1)(ember-source@3.27.5)(ember-tether@3.1.0):
+  ember-modal-dialog@4.1.5(@ember/string@4.0.1)(ember-source@3.27.5(@babel/core@7.24.3))(ember-tether@3.1.0(ember-source@3.27.5(@babel/core@7.24.3))(webpack@5.91.0)):
     dependencies:
       '@babel/core': 7.28.0
       '@ember/string': 4.0.1
       '@embroider/macros': 1.18.1
-      '@embroider/util': 1.13.4(ember-source@3.27.5)
+      '@embroider/util': 1.13.4(ember-source@3.27.5(@babel/core@7.24.3))
       ember-cli-babel: 8.2.0(@babel/core@7.28.0)
       ember-cli-htmlbars: 6.3.0
       ember-cli-version-checker: 5.1.2
-      ember-tether: 3.1.0(ember-source@3.27.5)(webpack@5.91.0)
       ember-wormhole: 0.6.1
+    optionalDependencies:
+      ember-tether: 3.1.0(ember-source@3.27.5(@babel/core@7.24.3))(webpack@5.91.0)
     transitivePeerDependencies:
       - '@glint/environment-ember-loose'
       - '@glint/template'
@@ -25282,24 +25354,15 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-modifier-manager-polyfill@1.2.0(@babel/core@7.28.0):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-version-checker: 2.2.0
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  ember-modifier@2.1.2(@babel/core@7.28.0):
+  ember-modifier@2.1.2(@babel/core@7.24.3):
     dependencies:
       ember-cli-babel: 7.26.11
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-cli-typescript: 3.1.4(@babel/core@7.28.0)
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
-      ember-destroyable-polyfill: 2.0.3(@babel/core@7.28.0)
-      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.28.0)
+      ember-cli-typescript: 3.1.4(@babel/core@7.24.3)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
+      ember-destroyable-polyfill: 2.0.3(@babel/core@7.24.3)
+      ember-modifier-manager-polyfill: 1.2.0(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -25315,28 +25378,40 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-modifier@4.1.0(ember-source@4.8.4):
+  ember-modifier@4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       '@embroider/addon-shim': 1.8.7
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+    optionalDependencies:
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - supports-color
 
-  ember-modifier@4.1.0(ember-source@5.0.0):
+  ember-modifier@4.1.0(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)):
     dependencies:
       '@embroider/addon-shim': 1.8.7
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
-      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2)(webpack@5.101.0)
+    optionalDependencies:
+      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)
     transitivePeerDependencies:
       - supports-color
 
-  ember-modifier@4.2.2(@babel/core@7.28.0):
+  ember-modifier@4.1.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
+    dependencies:
+      '@embroider/addon-shim': 1.8.7
+      ember-cli-normalize-entity-name: 1.0.0
+      ember-cli-string-utils: 1.1.0
+    optionalDependencies:
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-modifier@4.2.2(@babel/core@7.24.3):
     dependencies:
       '@embroider/addon-shim': 1.10.0
-      decorator-transforms: 2.3.0(@babel/core@7.28.0)
+      decorator-transforms: 2.3.0(@babel/core@7.24.3)
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
     transitivePeerDependencies:
@@ -25355,16 +25430,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-poll@1.4.0(@babel/core@7.28.0):
+  ember-poll@1.4.0(@babel/core@7.24.3):
     dependencies:
-      ember-cli-babel: 6.18.0(@babel/core@7.28.0)
+      ember-cli-babel: 6.18.0(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-qunit@5.1.5(@ember/test-helpers@2.9.3)(qunit@2.19.4):
+  ember-qunit@5.1.5(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)))(qunit@2.19.4):
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.28.0)(ember-source@3.27.5)
+      '@ember/test-helpers': 2.9.3(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
@@ -25380,16 +25455,16 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  ember-qunit@6.2.0(@ember/test-helpers@2.9.3)(ember-source@4.8.4)(qunit@2.19.4)(webpack@5.81.0):
+  ember-qunit@6.2.0(@ember/test-helpers@2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)))(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(qunit@2.19.4)(webpack@5.81.0):
     dependencies:
-      '@ember/test-helpers': 2.9.3(@babel/core@7.28.0)(ember-source@4.8.4)
+      '@ember/test-helpers': 2.9.3(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.3(webpack@5.81.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
       qunit: 2.19.4
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -25398,16 +25473,16 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-qunit@7.0.0(@ember/test-helpers@3.0.3)(ember-source@5.0.0)(qunit@2.19.4)(webpack@5.89.0):
+  ember-qunit@7.0.0(@ember/test-helpers@3.0.3(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0))(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(qunit@2.19.4)(webpack@5.89.0):
     dependencies:
-      '@ember/test-helpers': 3.0.3(ember-source@5.0.0)(webpack@5.89.0)
+      '@ember/test-helpers': 3.0.3(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 3.0.2
       common-tags: 1.8.2
       ember-auto-import: 2.6.3(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-test-loader: 3.0.0
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
       qunit: 2.19.4
       resolve-package-path: 4.0.3
       silent-error: 1.1.1
@@ -25416,17 +25491,18 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-resolver@10.1.0(@ember/string@3.1.1)(ember-source@5.0.0):
+  ember-resolver@10.1.0(@ember/string@3.1.1)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
     dependencies:
       '@ember/string': 3.1.1
       ember-cli-babel: 7.26.11
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+    optionalDependencies:
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
     transitivePeerDependencies:
       - supports-color
 
-  ember-resolver@8.1.0(@babel/core@7.28.0):
+  ember-resolver@8.1.0(@babel/core@7.24.3):
     dependencies:
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       broccoli-funnel: 3.0.8
       broccoli-merge-trees: 4.2.0
       ember-cli-babel: 7.26.11
@@ -25436,15 +25512,16 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-resources@4.10.0(@ember/test-waiters@3.0.2)(@glimmer/tracking@1.1.2)(ember-concurrency@2.3.7)(ember-source@5.0.0):
+  ember-resources@4.10.0(@ember/test-waiters@3.1.0)(@glimmer/tracking@1.1.2)(ember-concurrency@2.3.7(@babel/core@7.17.10))(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)):
     dependencies:
       '@babel/runtime': 7.21.0
-      '@ember/test-waiters': 3.0.2
       '@embroider/addon-shim': 1.6.0
       '@embroider/macros': 1.10.0
       '@glimmer/tracking': 1.1.2
+      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)
+    optionalDependencies:
+      '@ember/test-waiters': 3.1.0
       ember-concurrency: 2.3.7(@babel/core@7.17.10)
-      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2)(webpack@5.101.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25464,11 +25541,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-router-scroll@4.1.2(@babel/core@7.28.0):
+  ember-router-scroll@4.1.2(@babel/core@7.24.3):
     dependencies:
-      ember-app-scheduler: 7.0.1(@babel/core@7.28.0)
+      ember-app-scheduler: 7.0.1(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.28.0)
+      ember-compatibility-helpers: 1.2.7(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -25479,14 +25556,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-sinon-qunit@7.1.4(ember-source@5.0.0)(qunit@2.19.4)(sinon@15.2.0)(webpack@5.89.0):
+  ember-sinon-qunit@7.1.4(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(qunit@2.19.4)(sinon@15.2.0)(webpack@5.89.0):
     dependencies:
       '@types/sinon': 10.0.14
       broccoli-funnel: 3.0.8
       ember-auto-import: 2.6.3(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-typescript: 5.2.1
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
       qunit: 2.19.4
       sinon: 15.2.0
     transitivePeerDependencies:
@@ -25502,15 +25579,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-sortable@2.4.0(@babel/core@7.28.0):
+  ember-sortable@2.4.0(@babel/core@7.24.3):
     dependencies:
-      '@ember/render-modifiers': 1.0.2(@babel/core@7.28.0)
+      '@ember/render-modifiers': 1.0.2(@babel/core@7.24.3)
       '@ember/test-waiters': 2.4.5
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 5.7.2
       ember-cli-version-checker: 5.1.2
       ember-get-config: 0.3.0
-      ember-modifier: 2.1.2(@babel/core@7.28.0)
+      ember-modifier: 2.1.2(@babel/core@7.24.3)
       ember-test-selectors: 5.5.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -25526,14 +25603,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@3.27.5(@babel/core@7.28.0):
+  ember-source@3.27.5(@babel/core@7.24.3):
     dependencies:
       '@babel/helper-module-imports': 7.24.3
-      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-object-assign': 7.25.7(@babel/core@7.28.0)
+      '@babel/plugin-transform-block-scoping': 7.24.1(@babel/core@7.24.3)
+      '@babel/plugin-transform-object-assign': 7.25.7(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
-      '@glimmer/vm-babel-plugins': 0.78.2(@babel/core@7.28.0)
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      '@glimmer/vm-babel-plugins': 0.78.2(@babel/core@7.24.3)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       babel-plugin-filter-imports: 4.0.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
@@ -25558,14 +25635,14 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-source@4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0):
+  ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0):
     dependencies:
       '@babel/helper-module-imports': 7.21.4
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
-      '@glimmer/component': 1.1.2(@babel/core@7.28.0)
-      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.28.0)
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      '@glimmer/component': 1.1.2(@babel/core@7.24.3)
+      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.24.3)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       babel-plugin-filter-imports: 4.0.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
@@ -25592,7 +25669,7 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2)(webpack@5.101.0):
+  ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0):
     dependencies:
       '@babel/helper-module-imports': 7.22.15
       '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.17.10)
@@ -25626,14 +25703,14 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-source@5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0):
+  ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0):
     dependencies:
       '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.24.3)
       '@ember/edition-utils': 1.2.0
-      '@glimmer/component': 1.1.2(@babel/core@7.28.0)
-      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.28.0)
-      babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
+      '@glimmer/component': 1.1.2(@babel/core@7.24.3)
+      '@glimmer/vm-babel-plugins': 0.84.2(@babel/core@7.24.3)
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.24.3)
       babel-plugin-filter-imports: 4.0.0
       broccoli-concat: 4.2.5
       broccoli-debug: 0.6.5
@@ -25660,10 +25737,9 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-stereo@file:ember-stereo(@babel/core@7.28.0)(@ember/string@3.1.1)(@ember/test-waiters@3.1.0)(ember-source@5.0.0)(webpack@5.89.0):
-    id: ember-stereo@file:ember-stereo
+  ember-stereo@file:ember-stereo(@babel/core@7.24.3)(@ember/string@3.1.1)(@ember/test-waiters@3.1.0)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0):
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@ember/string': 3.1.1
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.6.0
@@ -25674,25 +25750,24 @@ snapshots:
       ember-auto-import: 2.7.2(webpack@5.89.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-concurrency: 2.3.7(@babel/core@7.28.0)
-      ember-gesture-modifiers: 5.0.1(ember-source@5.0.0)(webpack@5.89.0)
+      ember-concurrency: 2.3.7(@babel/core@7.24.3)
+      ember-gesture-modifiers: 5.0.1(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))(webpack@5.89.0)
       ember-get-config: 2.1.1
-      ember-modifier: 4.1.0(ember-source@5.0.0)
+      ember-modifier: 4.1.0(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
       ember-sinon: 5.0.0
       hls.js: 1.5.15
       howler: '@tunein/howler@https://codeload.github.com/tunein/howler.js/tar.gz/5cd1ecff8d6df8f8793bd7126ccab317ea37feb4'
       tracked-built-ins: 3.1.1
-      tracked-toolbox: 2.0.0(@babel/core@7.28.0)(ember-source@5.0.0)
+      tracked-toolbox: 2.0.0(@babel/core@7.24.3)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0))
     transitivePeerDependencies:
       - '@glint/template'
       - ember-source
       - supports-color
       - webpack
 
-  ember-stereo@file:ember-stereo(@babel/core@7.28.0)(@ember/string@4.0.1)(@ember/test-waiters@3.1.0)(ember-source@4.8.4)(webpack@5.81.0):
-    id: ember-stereo@file:ember-stereo
+  ember-stereo@file:ember-stereo(@babel/core@7.24.3)(@ember/string@4.0.1)(@ember/test-waiters@3.1.0)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0):
     dependencies:
-      '@babel/core': 7.28.0
+      '@babel/core': 7.24.3
       '@ember/string': 4.0.1
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.6.0
@@ -25703,30 +25778,30 @@ snapshots:
       ember-auto-import: 2.7.2(webpack@5.81.0)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-concurrency: 2.3.7(@babel/core@7.28.0)
-      ember-gesture-modifiers: 5.0.1(ember-source@4.8.4)(webpack@5.81.0)
+      ember-concurrency: 2.3.7(@babel/core@7.24.3)
+      ember-gesture-modifiers: 5.0.1(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0)
       ember-get-config: 2.1.1
-      ember-modifier: 4.1.0(ember-source@4.8.4)
+      ember-modifier: 4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-sinon: 5.0.0
       hls.js: 1.5.15
       howler: '@tunein/howler@https://codeload.github.com/tunein/howler.js/tar.gz/5cd1ecff8d6df8f8793bd7126ccab317ea37feb4'
       tracked-built-ins: 3.1.1
-      tracked-toolbox: 2.0.0(@babel/core@7.28.0)(ember-source@4.8.4)
+      tracked-toolbox: 2.0.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
     transitivePeerDependencies:
       - '@glint/template'
       - ember-source
       - supports-color
       - webpack
 
-  ember-style-modifier@4.3.0(@ember/string@4.0.1)(ember-source@4.8.4):
+  ember-style-modifier@4.3.0(@ember/string@4.0.1)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       '@babel/core': 7.23.7
       '@ember/string': 4.0.1
       '@embroider/addon-shim': 1.8.7
       csstype: 3.1.3
       decorator-transforms: 1.1.0(@babel/core@7.23.7)
-      ember-modifier: 4.1.0(ember-source@4.8.4)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-modifier: 4.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25910,28 +25985,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-tether@3.1.0(ember-source@3.27.5)(webpack@5.91.0):
+  ember-tether@3.1.0(ember-source@3.27.5(@babel/core@7.24.3))(webpack@5.91.0):
     dependencies:
       '@babel/core': 7.24.3
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@3.27.5)
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3))
       ember-auto-import: 2.6.3(webpack@5.91.0)
       ember-cli-babel: 8.2.0(@babel/core@7.24.3)
       ember-cli-htmlbars: 6.3.0
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-source: 3.27.5(@babel/core@7.24.3)
       tether: 2.0.0
     transitivePeerDependencies:
       - '@glint/template'
       - supports-color
       - webpack
 
-  ember-tether@3.1.0(ember-source@4.8.4)(webpack@5.81.0):
+  ember-tether@3.1.0(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))(webpack@5.81.0):
     dependencies:
       '@babel/core': 7.24.3
-      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@4.8.4)
+      '@ember/render-modifiers': 2.1.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
       ember-auto-import: 2.6.3(webpack@5.81.0)
       ember-cli-babel: 8.2.0(@babel/core@7.24.3)
       ember-cli-htmlbars: 6.3.0
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
       tether: 2.0.0
     transitivePeerDependencies:
       - '@glint/template'
@@ -25951,19 +26026,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-truth-helpers@4.0.3(ember-source@3.27.5):
+  ember-truth-helpers@4.0.3(ember-source@3.27.5(@babel/core@7.24.3)):
     dependencies:
       '@embroider/addon-shim': 1.8.7
-      ember-functions-as-helper-polyfill: 2.1.2(ember-source@3.27.5)
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@3.27.5(@babel/core@7.24.3))
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - supports-color
 
-  ember-truth-helpers@4.0.3(ember-source@4.8.4):
+  ember-truth-helpers@4.0.3(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       '@embroider/addon-shim': 1.8.7
-      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.8.4)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0))
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25982,7 +26057,7 @@ snapshots:
       lodash: 4.17.21
       package-json: 6.5.0
       remote-git-tags: 3.0.0
-      semver: 7.6.0
+      semver: 7.7.2
     transitivePeerDependencies:
       - encoding
 
@@ -26297,10 +26372,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.21.0)(eslint-import-resolver-node@0.3.7)(eslint@7.32.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.7)(eslint@7.32.0):
     dependencies:
-      '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
       debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.7
     transitivePeerDependencies:
@@ -26381,16 +26457,15 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.21.0)(eslint@7.32.0):
+  eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint@7.32.0):
     dependencies:
-      '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.21.0)(eslint-import-resolver-node@0.3.7)(eslint@7.32.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.21.0(eslint@7.32.0)(typescript@5.9.2))(eslint-import-resolver-node@0.3.7)(eslint@7.32.0)
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -26398,6 +26473,8 @@ snapshots:
       object.values: 1.1.6
       resolve: 1.22.2
       tsconfig-paths: 3.14.2
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.21.0(eslint@7.32.0)(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -26430,40 +26507,37 @@ snapshots:
       resolve: 1.22.2
       semver: 6.3.0
 
-  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8):
+  eslint-plugin-prettier@3.4.1(eslint-config-prettier@8.8.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8):
     dependencies:
       eslint: 7.32.0
-      eslint-config-prettier: 8.8.0(eslint@7.32.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
+    optionalDependencies:
+      eslint-config-prettier: 8.8.0(eslint@7.32.0)
 
-  eslint-plugin-prettier@4.0.0(eslint-config-prettier@8.5.0)(eslint@7.32.0)(prettier@2.6.2):
+  eslint-plugin-prettier@4.0.0(eslint-config-prettier@8.5.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.6.2):
     dependencies:
       eslint: 7.32.0
-      eslint-config-prettier: 8.5.0(eslint@7.32.0)
       prettier: 2.6.2
       prettier-linter-helpers: 1.0.0
-
-  eslint-plugin-prettier@4.0.0(eslint-config-prettier@8.5.0)(eslint@7.32.0)(prettier@2.8.8):
-    dependencies:
-      eslint: 7.32.0
+    optionalDependencies:
       eslint-config-prettier: 8.5.0(eslint@7.32.0)
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@7.32.0)(prettier@2.8.8):
+  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@7.32.0))(eslint@7.32.0)(prettier@2.8.8):
     dependencies:
       eslint: 7.32.0
-      eslint-config-prettier: 8.8.0(eslint@7.32.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
+    optionalDependencies:
+      eslint-config-prettier: 8.8.0(eslint@7.32.0)
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0)(eslint@8.42.0)(prettier@2.8.8):
+  eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.8.0(eslint@8.42.0))(eslint@8.42.0)(prettier@2.8.8):
     dependencies:
       eslint: 8.42.0
-      eslint-config-prettier: 8.8.0(eslint@8.42.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
+    optionalDependencies:
+      eslint-config-prettier: 8.8.0(eslint@8.42.0)
 
   eslint-plugin-qunit@6.2.0(eslint@7.32.0):
     dependencies:
@@ -27122,11 +27196,11 @@ snapshots:
       readable-stream: 2.3.8
 
   follow-redirects@1.15.2(debug@4.3.2):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.2(supports-color@5.5.0)
 
   follow-redirects@1.15.9(debug@4.3.2):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.2(supports-color@5.5.0)
 
   for-each@0.3.3:
@@ -28508,8 +28582,8 @@ snapshots:
     dependencies:
       '@babel/polyfill': 7.12.1
       '@jimp/custom': 0.5.4(debug@4.3.2)
-      '@jimp/plugins': 0.5.5(@jimp/custom@0.5.4)(debug@4.3.2)
-      '@jimp/types': 0.5.4(@jimp/custom@0.5.4)
+      '@jimp/plugins': 0.5.5(@jimp/custom@0.5.4(debug@4.3.2))(debug@4.3.2)
+      '@jimp/types': 0.5.4(@jimp/custom@0.5.4(debug@4.3.2))
       core-js: 2.6.12
     transitivePeerDependencies:
       - debug
@@ -29090,7 +29164,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.7.2
 
   makeerror@1.0.12:
     dependencies:
@@ -29612,7 +29686,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.6.0
+      semver: 7.7.2
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -29655,7 +29729,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.13.1
-      semver: 7.6.0
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -29686,13 +29760,13 @@ snapshots:
     dependencies:
       hosted-git-info: 6.1.3
       proc-log: 3.0.0
-      semver: 7.5.4
+      semver: 7.7.2
       validate-npm-package-name: 5.0.0
 
   npm-package-arg@8.1.5:
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.6.0
+      semver: 7.7.2
       validate-npm-package-name: 3.0.0
 
   npm-package-arg@9.1.2:
@@ -30322,14 +30396,16 @@ snapshots:
   postcss-load-config@3.1.4(postcss@8.4.23):
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.23
       yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.23
 
   postcss-load-config@3.1.4(postcss@8.4.38):
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.38
       yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.4.38
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -30498,7 +30574,7 @@ snapshots:
   progress@2.0.3: {}
 
   promise-inflight@1.0.1(bluebird@3.7.2):
-    dependencies:
+    optionalDependencies:
       bluebird: 3.7.2
 
   promise-make-counter@1.0.1:
@@ -31453,7 +31529,7 @@ snapshots:
 
   simple-update-notifier@2.0.0:
     dependencies:
-      semver: 7.6.0
+      semver: 7.7.2
 
   sinon@15.2.0:
     dependencies:
@@ -31877,30 +31953,30 @@ snapshots:
 
   styled_string@0.0.1: {}
 
-  stylelint-config-recommended@12.0.0(stylelint@15.7.0):
+  stylelint-config-recommended@12.0.0(stylelint@15.7.0(typescript@5.9.2)):
     dependencies:
-      stylelint: 15.7.0
+      stylelint: 15.7.0(typescript@5.9.2)
 
-  stylelint-config-standard@33.0.0(stylelint@15.7.0):
+  stylelint-config-standard@33.0.0(stylelint@15.7.0(typescript@5.9.2)):
     dependencies:
-      stylelint: 15.7.0
-      stylelint-config-recommended: 12.0.0(stylelint@15.7.0)
+      stylelint: 15.7.0(typescript@5.9.2)
+      stylelint-config-recommended: 12.0.0(stylelint@15.7.0(typescript@5.9.2))
 
-  stylelint-prettier@3.0.0(prettier@2.8.8)(stylelint@15.7.0):
+  stylelint-prettier@3.0.0(prettier@2.8.8)(stylelint@15.7.0(typescript@5.9.2)):
     dependencies:
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
-      stylelint: 15.7.0
+      stylelint: 15.7.0(typescript@5.9.2)
 
-  stylelint@15.7.0:
+  stylelint@15.7.0(typescript@5.9.2):
     dependencies:
       '@csstools/css-parser-algorithms': 2.6.1(@csstools/css-tokenizer@2.2.4)
       '@csstools/css-tokenizer': 2.2.4
-      '@csstools/media-query-list-parser': 2.1.9(@csstools/css-parser-algorithms@2.6.1)(@csstools/css-tokenizer@2.2.4)
+      '@csstools/media-query-list-parser': 2.1.9(@csstools/css-parser-algorithms@2.6.1(@csstools/css-tokenizer@2.2.4))(@csstools/css-tokenizer@2.2.4)
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.16)
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 8.3.6
+      cosmiconfig: 8.3.6(typescript@5.9.2)
       css-functions-list: 3.2.1
       css-tree: 2.3.1
       debug: 4.3.4(supports-color@9.4.0)
@@ -32065,7 +32141,7 @@ snapshots:
       reduce-css-calc: 2.1.8
       resolve: 1.22.8
 
-  tailwindcss@2.2.19(autoprefixer@10.4.14)(postcss@8.4.23):
+  tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.23))(postcss@8.4.23):
     dependencies:
       arg: 5.0.2
       autoprefixer: 10.4.14(postcss@8.4.23)
@@ -32104,7 +32180,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@2.2.19(autoprefixer@10.4.14)(postcss@8.4.38):
+  tailwindcss@2.2.19(autoprefixer@10.4.14(postcss@8.4.38))(postcss@8.4.38):
     dependencies:
       arg: 5.0.2
       autoprefixer: 10.4.14(postcss@8.4.38)
@@ -32253,7 +32329,7 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
-  testem@3.10.1(debug@4.3.2):
+  testem@3.10.1(babel-core@6.26.3)(debug@4.3.2)(handlebars@4.7.8)(lodash@4.17.21)(underscore@1.13.6):
     dependencies:
       '@xmldom/xmldom': 0.8.7
       backbone: 1.4.1
@@ -32261,7 +32337,7 @@ snapshots:
       charm: 1.0.2
       commander: 2.20.3
       compression: 1.7.4
-      consolidate: 0.16.0(mustache@4.2.0)
+      consolidate: 0.16.0(babel-core@6.26.3)(handlebars@4.7.8)(lodash@4.17.21)(mustache@4.2.0)(underscore@1.13.6)
       execa: 1.0.0
       express: 4.18.2
       fireworm: 0.7.2
@@ -32513,46 +32589,50 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  tracked-toolbox@1.3.0(@babel/core@7.28.0):
+  tracked-toolbox@1.3.0(@babel/core@7.24.3):
     dependencies:
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
       ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@2.0.0(@babel/core@7.17.10)(ember-source@5.0.0):
+  tracked-toolbox@2.0.0(@babel/core@7.17.10)(ember-source@5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)):
     dependencies:
       '@embroider/addon-shim': 1.6.0
       ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.17.10)
-      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2)(webpack@5.101.0)
+    optionalDependencies:
+      ember-source: 5.0.0(@babel/core@7.17.10)(@glimmer/component@1.1.2(@babel/core@7.17.10))(webpack@5.101.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@2.0.0(@babel/core@7.28.0)(ember-source@3.27.5):
+  tracked-toolbox@2.0.0(@babel/core@7.24.3)(ember-source@3.27.5(@babel/core@7.24.3)):
     dependencies:
       '@embroider/addon-shim': 1.6.0
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
-      ember-source: 3.27.5(@babel/core@7.28.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
+    optionalDependencies:
+      ember-source: 3.27.5(@babel/core@7.24.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@2.0.0(@babel/core@7.28.0)(ember-source@4.8.4):
+  tracked-toolbox@2.0.0(@babel/core@7.24.3)(ember-source@4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)):
     dependencies:
       '@embroider/addon-shim': 1.6.0
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
-      ember-source: 4.8.4(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.81.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
+    optionalDependencies:
+      ember-source: 4.8.4(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.81.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@2.0.0(@babel/core@7.28.0)(ember-source@5.0.0):
+  tracked-toolbox@2.0.0(@babel/core@7.24.3)(ember-source@5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)):
     dependencies:
       '@embroider/addon-shim': 1.6.0
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.28.0)
-      ember-source: 5.0.0(@babel/core@7.28.0)(@glimmer/component@1.1.2)(webpack@5.89.0)
+      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.24.3)
+    optionalDependencies:
+      ember-source: 5.0.0(@babel/core@7.24.3)(@glimmer/component@1.1.2(@babel/core@7.24.3))(webpack@5.89.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
Hopefully fixes: https://github.com/jkeen/ember-stereo/issues/35

I'm surprised at how much stuff changed in `pnpn-lock.yaml` and I have no idea why.

Also, I'm not entirely sure if this will do the trick because I can't get a local install of this package to work in my project. Something to do with a `yarn`/`pnpm` incompatibility that I don't know how to resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened peer dependency compatibility for test waiters to include newer major versions, reducing peer warning noise and easing integration with up-to-date Ember setups.
  * Improves compatibility with projects using the latest Ember testing tools.
  * No functional changes or API adjustments; runtime behavior remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->