### PR TITLE
Fix deprecation warning for ember service

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ System volume. Bind a range element to this property for a simple volume control
 ```javascript
 
 //component.js
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 export default Component.extend({
   stereo: service(),
 })

--- a/docs/app/components/cached-sounds.js
+++ b/docs/app/components/cached-sounds.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class CachedSound extends Component {
   @service stereo;
 

--- a/docs/app/components/diagnostic-controls.js
+++ b/docs/app/components/diagnostic-controls.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 export default class DiagnosticControls extends Component {

--- a/docs/app/components/docs/autoplay-checking.js
+++ b/docs/app/components/docs/autoplay-checking.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 export default class AutoplayChecking extends Component {

--- a/docs/app/components/docs/autoplay-gotchas.js
+++ b/docs/app/components/docs/autoplay-gotchas.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/current-browser.js
+++ b/docs/app/components/docs/current-browser.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DocsCurrentBrowser extends Component {
   @service userAgent;

--- a/docs/app/components/docs/current-os.js
+++ b/docs/app/components/docs/current-os.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DocsCurrentBrowser extends Component {
   @service userAgent;

--- a/docs/app/components/docs/other-browser.js
+++ b/docs/app/components/docs/other-browser.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class DocsCurrentBrowser extends Component {
   @service userAgent;

--- a/docs/app/components/docs/proxy-example.js
+++ b/docs/app/components/docs/proxy-example.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 // BEGIN-SNIPPET proxy-example.js

--- a/docs/app/components/docs/queued.js
+++ b/docs/app/components/docs/queued.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 // BEGIN-SNIPPET queued.js

--- a/docs/app/components/docs/service-errors-silence-error.js
+++ b/docs/app/components/docs/service-errors-silence-error.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/service-errors-throw-error.js
+++ b/docs/app/components/docs/service-errors-throw-error.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/service-errors-try-catch.js
+++ b/docs/app/components/docs/service-errors-try-catch.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task } from 'ember-concurrency';
 
 export default class ServiceExample extends Component {

--- a/docs/app/components/docs/service-errors-try-then.js
+++ b/docs/app/components/docs/service-errors-try-then.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/service-example.js
+++ b/docs/app/components/docs/service-example.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/stereo-player-audio-debug.js
+++ b/docs/app/components/docs/stereo-player-audio-debug.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class DocsStereoPlayerAudioDebugComponent extends Component {
   @service stereo;
 

--- a/docs/app/components/docs/stereo-player-changer.js
+++ b/docs/app/components/docs/stereo-player-changer.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 

--- a/docs/app/components/docs/try-multiple-urls.js
+++ b/docs/app/components/docs/try-multiple-urls.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
 

--- a/docs/app/components/event-display.js
+++ b/docs/app/components/event-display.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { EVENT_MAP, SERVICE_EVENT_MAP } from 'ember-stereo/services/stereo';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { A as emberArray } from '@ember/array';
 import { set } from '@ember/object';
 import { task, didCancel } from 'ember-concurrency';

--- a/docs/app/components/service-display.js
+++ b/docs/app/components/service-display.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ServiceDisplay extends Component {

--- a/docs/app/components/sound-display.js
+++ b/docs/app/components/sound-display.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import hasEqualUrls from 'ember-stereo/-private/utils/has-equal-urls';

--- a/docs/app/components/sound-display/position.js
+++ b/docs/app/components/sound-display/position.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { throttle, next } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 export default class Position extends Component {

--- a/docs/app/components/sound-display/volume.js
+++ b/docs/app/components/sound-display/volume.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 export default class Volume extends Component {
   @service stereo;

--- a/docs/app/components/strategy-breakdown.js
+++ b/docs/app/components/strategy-breakdown.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import StereoUrl from 'ember-stereo/-private/utils/stereo-url';
 import Strategy from 'ember-stereo/-private/utils/strategy';

--- a/docs/app/controllers/docs.js
+++ b/docs/app/controllers/docs.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class DocsController extends Controller {
   @service media;
   @service stereo;

--- a/docs/app/controllers/docs/playing-sounds.js
+++ b/docs/app/controllers/docs/playing-sounds.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { timeout } from 'ember-concurrency';
 import { task } from 'ember-concurrency';
 export default class DocsUsageController extends Controller {

--- a/docs/app/routes/diagnostic.js
+++ b/docs/app/routes/diagnostic.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import testSounds from 'docs/utils/test-sounds';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class Diagnostic extends Route {
   @service stereo;
 

--- a/docs/app/routes/index.js
+++ b/docs/app/routes/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class IndexRoute extends Route {
   @service stereo;
   @service media;

--- a/docs/app/services/audio.js
+++ b/docs/app/services/audio.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 export default class Audio extends Service {
   @service stereo;
 

--- a/ember-stereo/README.md
+++ b/ember-stereo/README.md
@@ -323,7 +323,7 @@ System volume. Bind a range element to this property for a simple volume control
 ```javascript
 
 //component.js
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 export default Component.extend({
   stereo: service(),
 })

--- a/ember-stereo/src/-private/helpers/action-helper.js
+++ b/ember-stereo/src/-private/helpers/action-helper.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 import prepareOptions from '../utils/prepare-options';
 import { dedupeTracked } from 'tracked-toolbox';

--- a/ember-stereo/src/-private/helpers/is-helper.js
+++ b/ember-stereo/src/-private/helpers/is-helper.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 import { dedupeTracked } from 'tracked-toolbox';
 

--- a/ember-stereo/src/-private/utils/error-cache.js
+++ b/ember-stereo/src/-private/utils/error-cache.js
@@ -3,7 +3,7 @@ import debug from 'debug';
 import { tracked } from '@glimmer/tracking';
 import hasEqualUrls from './has-equal-urls';
 import normalizeIdentifier from './normalize-identifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
  * This class caches errors based on urls.

--- a/ember-stereo/src/-private/utils/object-cache.js
+++ b/ember-stereo/src/-private/utils/object-cache.js
@@ -1,5 +1,5 @@
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import normalizeIdentifier from './normalize-identifier';
 import { TrackedObject, TrackedWeakMap } from 'tracked-built-ins';
 import { makeArray } from '@ember/array';

--- a/ember-stereo/src/-private/utils/one-at-a-time.js
+++ b/ember-stereo/src/-private/utils/one-at-a-time.js
@@ -1,7 +1,7 @@
 import { A as emberArray } from '@ember/array';
 import debug from 'debug';
 import hasEqualUrls from './has-equal-urls';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 export default class OneAtATime {
   @service stereo;
 

--- a/ember-stereo/src/-private/utils/sound-cache.js
+++ b/ember-stereo/src/-private/utils/sound-cache.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import BaseSound from '../../stereo-connections/base';
 import hasEqualUrls from './has-equal-urls';
 import normalizeIdentifier from './normalize-identifier';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { TrackedObject, TrackedArray } from 'tracked-built-ins';
 
 /**

--- a/ember-stereo/src/helpers/autoplay-allowed.js
+++ b/ember-stereo/src/helpers/autoplay-allowed.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 /**

--- a/ember-stereo/src/helpers/current-sound.js
+++ b/ember-stereo/src/helpers/current-sound.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 /**

--- a/ember-stereo/src/helpers/load-sound.js
+++ b/ember-stereo/src/helpers/load-sound.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 import prepareOptions from '../-private/utils/prepare-options';
 import { didCancel } from 'ember-concurrency';

--- a/ember-stereo/src/helpers/sound-error-details.js
+++ b/ember-stereo/src/helpers/sound-error-details.js
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { dedupeTracked } from 'tracked-toolbox';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import debugMessage from '../-private/utils/debug-message';
 import hasEqualUrls from '../-private/utils/has-equal-urls';
 

--- a/ember-stereo/src/helpers/sound-is-errored.js
+++ b/ember-stereo/src/helpers/sound-is-errored.js
@@ -1,7 +1,7 @@
 import Helper from '@ember/component/helper';
 import { dedupeTracked } from 'tracked-toolbox';
 import hasEqualUrls from '../-private/utils/has-equal-urls';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
   A helper to detect if a sound is errored.

--- a/ember-stereo/src/helpers/sound-metadata.js
+++ b/ember-stereo/src/helpers/sound-metadata.js
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { get } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
   A helper to detect if a sound is playing.

--- a/ember-stereo/src/helpers/stereo-volume-is-adjustable.js
+++ b/ember-stereo/src/helpers/stereo-volume-is-adjustable.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 /**

--- a/ember-stereo/src/helpers/stereo-volume.js
+++ b/ember-stereo/src/helpers/stereo-volume.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 /**
   returns current stereo volume when used as a helper. When used as a modifier it transforms an range input control into a volume control

--- a/ember-stereo/src/helpers/toggle-stereo-mute.js
+++ b/ember-stereo/src/helpers/toggle-stereo-mute.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Helper from '@ember/component/helper';
 
 /**

--- a/ember-stereo/src/modifiers/sound-position-progress.js
+++ b/ember-stereo/src/modifiers/sound-position-progress.js
@@ -12,7 +12,7 @@
   @param {Integer} duration
 */
 
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Modifier from 'ember-modifier';
 import debug from 'debug';
 

--- a/ember-stereo/src/modifiers/sound-position-slider.js
+++ b/ember-stereo/src/modifiers/sound-position-slider.js
@@ -16,7 +16,7 @@
 */
 
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { task, waitForProperty } from 'ember-concurrency';
 import { next } from '@ember/runloop';
 import DidPanModifier from 'ember-gesture-modifiers/modifiers/did-pan';

--- a/ember-stereo/src/modifiers/stereo-volume.js
+++ b/ember-stereo/src/modifiers/stereo-volume.js
@@ -11,7 +11,7 @@
 
 import { registerDestructor } from '@ember/destroyable';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Modifier from 'ember-modifier';
 export default class StereoVolumeModifier extends Modifier {
   @service stereo;

--- a/test-app/app/services/audio.js
+++ b/test-app/app/services/audio.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 export default class Audio extends Service {
   @service stereo;
 


### PR DESCRIPTION
Fixes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple examples and guides to use the current Ember service import style.
  * Refreshed code snippets across the docs and README so they match the latest recommended syntax.

* **Refactor**
  * Aligned app, helper, modifier, route, and service imports with the newer named service export.
  * No behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->